### PR TITLE
Stop page-inspect from flagging the implicit /favicon.ico request as a failed resource

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gipity",
-  "version": "1.0.355",
+  "version": "1.0.360",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gipity",
-      "version": "1.0.355",
+      "version": "1.0.360",
       "license": "MIT",
       "dependencies": {
         "commander": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
   "name": "gipity",
-  "version": "1.0.355",
+  "version": "1.0.360",
   "description": "The full-stack platform tuned for AI agents. Database, storage, auth, functions, deploy, and drop-in kits - all agent-tuned. Pair with Claude Code or use standalone.",
   "bin": {
-    "gipity": "./dist/updater/shim.js",
-    "gipcc": "./dist/gipcc.js",
-    "gipccd": "./dist/gipccd.js"
+    "gipity": "dist/updater/shim.js",
+    "gipcc": "dist/gipcc.js",
+    "gipccd": "dist/gipccd.js"
   },
   "type": "module",
   "scripts": {
     "build": "tsc && chmod +x dist/index.js dist/gipcc.js dist/gipccd.js dist/updater/shim.js dist/updater/check.js",
     "dev": "tsc --watch",
     "test": "npm run test:smoke",
-    "test:smoke": "tsc && node --test dist/__tests__/utils.test.js dist/__tests__/config.test.js dist/__tests__/sync.test.js dist/__tests__/sync-apply.test.js dist/__tests__/sync-lock.test.js dist/__tests__/push-cas.test.js dist/__tests__/upload.test.js dist/__tests__/updater.test.js dist/__tests__/cli-smoke.test.js dist/__tests__/claude-noninteractive.test.js dist/__tests__/claude-trust.test.js dist/__tests__/relay-state.test.js dist/__tests__/relay-daemon.test.js dist/__tests__/relay-installers.test.js dist/__tests__/relay-bridge-abort.test.js dist/__tests__/relay-redact.test.js dist/__tests__/relay-machine-id.test.js dist/__tests__/stream-json.test.js dist/__tests__/relay-ingest-contract.test.js dist/__tests__/prompts.test.js dist/__tests__/capture-transcript.test.js dist/__tests__/flag-aliases.test.js dist/__tests__/adopt-cwd.test.js dist/__tests__/cli-cmd-agent.test.js dist/__tests__/cli-cmd-approval.test.js dist/__tests__/cli-cmd-audit.test.js dist/__tests__/cli-cmd-chat.test.js dist/__tests__/cli-cmd-credits.test.js dist/__tests__/cli-cmd-db.test.js dist/__tests__/cli-cmd-deploy.test.js dist/__tests__/cli-cmd-domain.test.js dist/__tests__/cli-cmd-email.test.js dist/__tests__/cli-cmd-file.test.js dist/__tests__/cli-cmd-fn.test.js dist/__tests__/cli-cmd-job.test.js dist/__tests__/cli-cmd-generate.test.js dist/__tests__/cli-cmd-gmail.test.js dist/__tests__/cli-cmd-info.test.js dist/__tests__/cli-cmd-init.test.js dist/__tests__/cli-cmd-location.test.js dist/__tests__/cli-cmd-login.test.js dist/__tests__/cli-cmd-logout.test.js dist/__tests__/cli-cmd-logs.test.js dist/__tests__/cli-cmd-memory.test.js dist/__tests__/cli-cmd-page.test.js dist/__tests__/cli-cmd-plan.test.js dist/__tests__/cli-cmd-project.test.js dist/__tests__/cli-cmd-rbac.test.js dist/__tests__/cli-cmd-realtime.test.js dist/__tests__/cli-cmd-records.test.js dist/__tests__/cli-cmd-relay.test.js dist/__tests__/cli-cmd-sandbox.test.js dist/__tests__/cli-cmd-add.test.js dist/__tests__/cli-cmd-skill.test.js dist/__tests__/cli-cmd-test.test.js dist/__tests__/cli-cmd-workflow.test.js dist/__tests__/setup-skills-block.test.js",
-    "test:e2e": "tsc && GIPITY_E2E=1 node --test --test-timeout=180000 dist/__tests__/cli-e2e-live.test.js"
+    "test:smoke": "tsc && node --test dist/__tests__/utils.test.js dist/__tests__/config.test.js dist/__tests__/sync.test.js dist/__tests__/sync-apply.test.js dist/__tests__/sync-lock.test.js dist/__tests__/push-cas.test.js dist/__tests__/upload.test.js dist/__tests__/updater.test.js dist/__tests__/cli-smoke.test.js dist/__tests__/claude-noninteractive.test.js dist/__tests__/claude-trust.test.js dist/__tests__/relay-state.test.js dist/__tests__/relay-daemon.test.js dist/__tests__/relay-installers.test.js dist/__tests__/relay-bridge-abort.test.js dist/__tests__/relay-redact.test.js dist/__tests__/relay-machine-id.test.js dist/__tests__/stream-json.test.js dist/__tests__/relay-ingest-contract.test.js dist/__tests__/prompts.test.js dist/__tests__/capture-transcript.test.js dist/__tests__/flag-aliases.test.js dist/__tests__/adopt-cwd.test.js dist/__tests__/cli-cmd-agent.test.js dist/__tests__/cli-cmd-approval.test.js dist/__tests__/cli-cmd-audit.test.js dist/__tests__/cli-cmd-chat.test.js dist/__tests__/cli-cmd-credits.test.js dist/__tests__/cli-cmd-db.test.js dist/__tests__/cli-cmd-deploy.test.js dist/__tests__/cli-cmd-domain.test.js dist/__tests__/cli-cmd-email.test.js dist/__tests__/cli-cmd-file.test.js dist/__tests__/cli-cmd-fn.test.js dist/__tests__/cli-cmd-service.test.js dist/__tests__/cli-cmd-job.test.js dist/__tests__/cli-cmd-generate.test.js dist/__tests__/cli-cmd-gmail.test.js dist/__tests__/cli-cmd-info.test.js dist/__tests__/cli-cmd-init.test.js dist/__tests__/cli-cmd-location.test.js dist/__tests__/cli-cmd-login.test.js dist/__tests__/cli-cmd-logout.test.js dist/__tests__/cli-cmd-logs.test.js dist/__tests__/cli-cmd-memory.test.js dist/__tests__/cli-cmd-page.test.js dist/__tests__/cli-cmd-plan.test.js dist/__tests__/cli-cmd-project.test.js dist/__tests__/cli-cmd-rbac.test.js dist/__tests__/cli-cmd-realtime.test.js dist/__tests__/cli-cmd-records.test.js dist/__tests__/cli-cmd-relay.test.js dist/__tests__/cli-cmd-sandbox.test.js dist/__tests__/cli-cmd-add.test.js dist/__tests__/cli-cmd-skill.test.js dist/__tests__/cli-cmd-test.test.js dist/__tests__/cli-cmd-workflow.test.js dist/__tests__/setup-skills-block.test.js",
+    "test:e2e": "tsc && GIPITY_E2E=1 node --test --test-timeout=180000 dist/__tests__/cli-e2e-live.test.js dist/__tests__/cli-e2e-services-media-live.test.js dist/__tests__/cli-e2e-workflow-live.test.js"
   },
   "dependencies": {
     "commander": "^13.0.0",
@@ -28,7 +28,8 @@
     "node": ">=18"
   },
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "!dist/__tests__/**",
     "hooks"
   ],
   "license": "MIT"

--- a/src/__tests__/capture-transcript.test.ts
+++ b/src/__tests__/capture-transcript.test.ts
@@ -60,10 +60,35 @@ describe('transcriptLineToEntries', () => {
     assert.equal(out.length, 2);
     assert.equal(out[0].kind, 'assistant');
     assert.equal((out[0] as any).text, 'running:\ndone');
+    // The primary entry keeps the bare line uuid; the sibling tool_use gets a
+    // deterministic #N suffix so the server's (conversation_id, source_uuid)
+    // dedup index does NOT drop it. Without this, the tool row lost its name.
     assert.equal((out[0] as any).source_uuid, 'a1');
     assert.equal(out[1].kind, 'tool_use');
     assert.equal((out[1] as any).tool_name, 'Bash');
-    assert.equal((out[1] as any).source_uuid, 'a1');
+    assert.equal((out[1] as any).source_uuid, 'a1#1');
+  });
+
+  it('gives every entry from one line a UNIQUE source_uuid (dedup-collision regression)', () => {
+    // An assistant turn with text + two parallel tool calls. All three entries
+    // derive from the same transcript line. Before the fix they shared the bare
+    // line uuid and the server dropped both tool_use rows on ON CONFLICT.
+    const out = transcriptLineToEntries({
+      type: 'assistant',
+      uuid: 'a9',
+      message: {
+        content: [
+          { type: 'text', text: 'doing two things' },
+          { type: 'tool_use', id: 'tool_x', name: 'Read', input: { file: 'a' } },
+          { type: 'tool_use', id: 'tool_y', name: 'Bash', input: { command: 'ls' } },
+        ],
+      },
+    });
+    assert.equal(out.length, 3);
+    const uuids = out.map(e => (e as any).source_uuid);
+    assert.deepEqual(uuids, ['a9', 'a9#1', 'a9#2']);
+    // The invariant that matters: no two entries collide.
+    assert.equal(new Set(uuids).size, out.length);
   });
 });
 

--- a/src/__tests__/cli-cmd-page.test.ts
+++ b/src/__tests__/cli-cmd-page.test.ts
@@ -63,6 +63,50 @@ test('gipity page inspect flags horizontal overflow and lists culprits under --a
   assert.match(r.stdout, /div\.hero/);
 });
 
+test('gipity page inspect treats the implicit root /favicon.ico 404 as a note, not a failure', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/inspect', { body: { data: {
+    ...baseBundle, failedResources: ['https://dev.gipity.ai/favicon.ico (404)'],
+  } } });
+  const r = await run(['page', 'inspect', 'https://dev.gipity.ai/steve/app/']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.doesNotMatch(r.stdout, /Failed resources/);
+  assert.match(r.stdout, /No root \/favicon\.ico/);
+});
+
+test('gipity page inspect still flags real failed resources alongside the favicon note', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/inspect', { body: { data: {
+    ...baseBundle,
+    failedResources: ['https://dev.gipity.ai/favicon.ico (404)', 'https://dev.gipity.ai/app.js (500)'],
+  } } });
+  const r = await run(['page', 'inspect', 'https://dev.gipity.ai/steve/app/']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /Failed resources \(1\)/);
+  assert.match(r.stdout, /app\.js \(500\)/);
+  assert.doesNotMatch(r.stdout, /favicon\.ico \(404\)/);
+  assert.match(r.stdout, /No root \/favicon\.ico/);
+});
+
+test('gipity page inspect --fake-media forwards fakeMedia in the request body', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/inspect', { body: { data: baseBundle } });
+  const r = await run(['page', 'inspect', 'https://example.com', '--fake-media']);
+  assert.equal(r.status, 0, r.stderr);
+  const req = mock.requests().find(q => q.url === '/tools/browser/inspect');
+  assert.ok(req, 'inspect request was received');
+  assert.equal((req!.body as { fakeMedia?: boolean }).fakeMedia, true);
+});
+
+test('gipity page inspect omits fakeMedia when --fake-media is absent', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/inspect', { body: { data: baseBundle } });
+  const r = await run(['page', 'inspect', 'https://example.com']);
+  assert.equal(r.status, 0, r.stderr);
+  const req = mock.requests().find(q => q.url === '/tools/browser/inspect');
+  assert.equal((req!.body as { fakeMedia?: boolean }).fakeMedia, undefined);
+});
+
 test('gipity page inspect --json emits the raw inspect bundle', async () => {
   mock.reset();
   mock.on('POST /tools/browser/inspect', { body: { data: {
@@ -75,10 +119,13 @@ test('gipity page inspect --json emits the raw inspect bundle', async () => {
   assert.equal(parsed.overflow.overflowX, false);
 });
 
+// Eval is async: POST returns a job id, the CLI polls GET until the job is
+// done. The mock returns a fixed evalJobId and the matching done record.
 test('gipity page eval prints the serialized expression result', async () => {
   mock.reset();
-  mock.on('POST /tools/browser/eval', { body: { data: {
-    url: 'https://example.com', result: 'Example Domain', truncated: false,
+  mock.on('POST /tools/browser/eval', { body: { data: { evalJobId: 'job-1', status: 'queued' } } });
+  mock.on('GET /tools/browser/eval/job-1', { body: { data: {
+    status: 'done', url: 'https://example.com', result: 'Example Domain', truncated: false,
   } } });
   const r = await run(['page', 'eval', 'https://example.com', 'document.title']);
   assert.equal(r.status, 0, r.stderr);
@@ -88,12 +135,24 @@ test('gipity page eval prints the serialized expression result', async () => {
 
 test('gipity page eval --json emits url, result, and truncated', async () => {
   mock.reset();
-  mock.on('POST /tools/browser/eval', { body: { data: {
-    url: 'https://example.com', result: '42', truncated: true,
+  mock.on('POST /tools/browser/eval', { body: { data: { evalJobId: 'job-1', status: 'queued' } } });
+  mock.on('GET /tools/browser/eval/job-1', { body: { data: {
+    status: 'done', url: 'https://example.com', result: '42', truncated: true,
   } } });
   const r = await run(['page', 'eval', 'https://example.com', '1+41', '--json']);
   assert.equal(r.status, 0, r.stderr);
   const parsed = JSON.parse(r.stdout.trim());
   assert.equal(parsed.result, '42');
   assert.equal(parsed.truncated, true);
+});
+
+test('gipity page eval surfaces a failed eval job', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/eval', { body: { data: { evalJobId: 'job-err', status: 'queued' } } });
+  mock.on('GET /tools/browser/eval/job-err', { body: { data: {
+    status: 'error', httpStatus: 502, code: 'BROWSER_ERROR', reason: 'stayed on about:blank',
+  } } });
+  const r = await run(['page', 'eval', 'https://example.com', 'document.title']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /about:blank/);
 });

--- a/src/__tests__/cli-cmd-service.test.ts
+++ b/src/__tests__/cli-cmd-service.test.ts
@@ -1,0 +1,53 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { runCliAsync } from './helpers/spawn-cli.js';
+import { startMockServer, MockServer } from './helpers/mock-server.js';
+import { makeAuthedHome, makeProjectDir } from './helpers/test-home.js';
+
+let mock: MockServer;
+let home: string;
+
+before(async () => { mock = await startMockServer(); home = makeAuthedHome(); });
+after(async () => { await mock.stop(); });
+
+function fresh(args: string[]) {
+  const d = makeProjectDir({ apiBase: mock.apiBase });
+  return runCliAsync(['--api-base', mock.apiBase, ...args], { env: { HOME: home }, cwd: d });
+}
+
+test('gipity service list shows the service catalog', async () => {
+  mock.reset();
+  const r = await fresh(['service', 'list']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /llm/);
+  assert.match(r.stdout, /image/);
+  assert.match(r.stdout, /music/);
+  assert.doesNotMatch(r.stdout, /undefined/);
+});
+
+test('gipity service call <name> [body] POSTs to /services/<name> and prints the raw response', async () => {
+  mock.reset();
+  // Service responses are NOT wrapped in { data } - the whole body is printed.
+  mock.on('POST /api/p_TestProj/services/llm', { body: { choices: [{ message: { content: 'ok' } }] } });
+  const r = await fresh(['service', 'call', 'llm', '{"prompt":"hi"}']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /choices/);
+  assert.match(r.stdout, /ok/);
+  assert.doesNotMatch(r.stdout, /undefined/);
+});
+
+test('gipity service call preserves subpaths (location/geocode)', async () => {
+  mock.reset();
+  mock.on('POST /api/p_TestProj/services/location/geocode', { body: { city: 'Portland' } });
+  const r = await fresh(['service', 'call', 'location/geocode', '{"lat":45.5,"lon":-122.6}']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /Portland/);
+});
+
+test('gipity service call --get issues a GET (listing endpoints)', async () => {
+  mock.reset();
+  mock.on('GET /api/p_TestProj/services/llm/models', { body: { data: { models: [{ id: 'claude-sonnet-4-6' }] } } });
+  const r = await fresh(['service', 'call', 'llm/models', '--get']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /claude-sonnet-4-6/);
+});

--- a/src/__tests__/cli-cmd-workflow.test.ts
+++ b/src/__tests__/cli-cmd-workflow.test.ts
@@ -31,7 +31,7 @@ test('gipity workflow lists workflows with active counters', async () => {
 
 test('gipity workflow info <name> resolves by name and shows details', async () => {
   mock.reset();
-  mock.on('GET /workflows', { body: { data: [WF_A, WF_B], meta: { activeCount: 1, activeLimit: 50 } } });
+  mock.on('GET /projects/p_TestProj/workflows', { body: { data: [WF_A, WF_B] } });
   mock.on('GET /workflows/wf_WflowAa0', { body: { data: { ...WF_A, steps: [{ step_order: 1, name: 'step1', model: 'claude-sonnet-4-6' }] } } });
   const r = await fresh(['workflow', 'info', 'Daily']);
   assert.equal(r.status, 0, r.stderr);
@@ -44,7 +44,7 @@ test('gipity workflow info <name> resolves by name and shows details', async () 
 
 test('gipity workflow run <name> POSTs and prints triggered', async () => {
   mock.reset();
-  mock.on('GET /workflows', { body: { data: [WF_A], meta: { activeCount: 1, activeLimit: 50 } } });
+  mock.on('GET /projects/p_TestProj/workflows', { body: { data: [WF_A] } });
   mock.on('POST /workflows/wf_WflowAa0/run', { body: { data: { message: 'queued', workflow_guid: 'wf_WflowAa0' } } });
   const r = await fresh(['workflow', 'run', 'Daily']);
   assert.equal(r.status, 0, r.stderr);
@@ -53,7 +53,7 @@ test('gipity workflow run <name> POSTs and prints triggered', async () => {
 
 test('gipity workflow runs <name> lists recent runs', async () => {
   mock.reset();
-  mock.on('GET /workflows', { body: { data: [WF_A], meta: { activeCount: 1, activeLimit: 50 } } });
+  mock.on('GET /projects/p_TestProj/workflows', { body: { data: [WF_A] } });
   mock.on('GET /workflows/wf_WflowAa0/runs', { body: { data: [
     { short_guid: 'wr_Run00001', status: 'completed', started_at: '2026-05-01T10:00:00Z', completed_at: '2026-05-01T10:00:05Z', total_tokens: 100 },
     { short_guid: 'wr_Run00002', status: 'failed',    started_at: '2026-05-02T10:00:00Z', completed_at: null, total_tokens: 50 },
@@ -68,8 +68,9 @@ test('gipity workflow runs <name> lists recent runs', async () => {
 
 test('gipity workflow enable <name> PUTs is_active=true', async () => {
   mock.reset();
-  mock.on('GET /workflows', { body: { data: [WF_A], meta: { activeCount: 1, activeLimit: 50 } } });
-  mock.on('PUT /workflows/wf_WflowAa0', { body: { data: {} } });
+  mock.on('GET /projects/p_TestProj/workflows', { body: { data: [WF_A] } });
+  // enable verifies the PUT took effect, so the response must reflect is_active.
+  mock.on('PUT /workflows/wf_WflowAa0', { body: { data: { ...WF_A, is_active: 1 } } });
   const r = await fresh(['workflow', 'enable', 'Daily']);
   assert.equal(r.status, 0, r.stderr);
   assert.match(r.stdout, /Enabled "Daily"/);
@@ -77,8 +78,9 @@ test('gipity workflow enable <name> PUTs is_active=true', async () => {
 
 test('gipity workflow disable <name> PUTs is_active=false', async () => {
   mock.reset();
-  mock.on('GET /workflows', { body: { data: [WF_A], meta: { activeCount: 1, activeLimit: 50 } } });
-  mock.on('PUT /workflows/wf_WflowAa0', { body: { data: {} } });
+  mock.on('GET /projects/p_TestProj/workflows', { body: { data: [WF_A] } });
+  // disable verifies is_active went falsy, so the response must reflect that.
+  mock.on('PUT /workflows/wf_WflowAa0', { body: { data: { ...WF_A, is_active: 0 } } });
   const r = await fresh(['workflow', 'disable', 'Daily']);
   assert.equal(r.status, 0, r.stderr);
   assert.match(r.stdout, /Disabled "Daily"/);
@@ -86,8 +88,10 @@ test('gipity workflow disable <name> PUTs is_active=false', async () => {
 
 test('gipity workflow delete <name> calls DELETE', async () => {
   mock.reset();
-  mock.on('GET /workflows', { body: { data: [WF_A], meta: { activeCount: 1, activeLimit: 50 } } });
+  mock.on('GET /projects/p_TestProj/workflows', { body: { data: [WF_A] } });
   mock.on('DELETE /workflows/wf_WflowAa0', { body: { data: {} } });
+  // delete is a soft-delete; the command re-GETs to confirm is_active went 0.
+  mock.on('GET /workflows/wf_WflowAa0', { body: { data: { ...WF_A, is_active: 0 } } });
   const r = await fresh(['workflow', 'delete', 'Daily']);
   assert.equal(r.status, 0, r.stderr);
   assert.match(r.stdout, /Deleted "Daily"/);

--- a/src/__tests__/cli-e2e-services-media-live.test.ts
+++ b/src/__tests__/cli-e2e-services-media-live.test.ts
@@ -1,0 +1,137 @@
+// Real platform e2e for `gipity service call` and `page inspect|screenshot
+// --fake-media`. Skipped unless GIPITY_E2E=1 is set. Verifies the live deploy,
+// not a mock - mirrors the manual verification done when the feature shipped.
+//
+// Cost profile: ~$0.001 (one tiny LLM turn). Everything else is free CRUD +
+// the browser pool. Uses dev-bypass auth (magic code 914914) with an `ec-`
+// prefixed @914-6.com email so the platform suppresses real outbound mail.
+//
+// Env overrides:
+//   GIPITY_E2E=1                     enable the suite
+//   GIPITY_E2E_API_BASE=...          default https://a.gipity.ai
+//   GIPITY_E2E_EMAIL=ec-cli-sm@914-6.com
+//   GIPITY_E2E_CODE=914914
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { runCli, makeTmpHome } from './helpers/spawn-cli.js';
+
+const E2E_ENABLED = process.env['GIPITY_E2E'] === '1';
+const API_BASE = process.env['GIPITY_E2E_API_BASE'] ?? 'https://a.gipity.ai';
+const EMAIL = process.env['GIPITY_E2E_EMAIL'] ?? 'ec-cli-sm@914-6.com';
+const CODE = process.env['GIPITY_E2E_CODE'] ?? '914914';
+
+if (E2E_ENABLED && !EMAIL.startsWith('ec')) {
+  throw new Error(`E2E test email must start with "ec" to suppress real outbound mail: got "${EMAIL}"`);
+}
+
+// Probe page: call getUserMedia on load and log the outcome to the console.
+// `page inspect` returns the console bundle, so the result is observable. With
+// --fake-media Chrome gets a synthetic mic+cam and auto-grants the prompt, so
+// this resolves; without it, headless Chrome has no real device and rejects.
+const PROBE_MAIN_JS = `navigator.mediaDevices.getUserMedia({ audio: true, video: true })
+  .then(s => { console.log('MEDIA_OK audio=' + s.getAudioTracks().length + ' video=' + s.getVideoTracks().length); s.getTracks().forEach(t => t.stop()); })
+  .catch(e => console.error('MEDIA_FAIL ' + e.name));
+`;
+
+describe('cli-e2e-services-media-live', { skip: !E2E_ENABLED && 'set GIPITY_E2E=1 to run' }, () => {
+  const tmpHome = makeTmpHome();
+  const projectDir = mkdtempSync(join(tmpdir(), 'gipity-e2e-sm-'));
+  const projectSlug = `gip-e2e-sm-${Date.now().toString(36)}`;
+  const env = { HOME: tmpHome };
+  let appUrl = '';
+
+  const cli = (args: string[], opts: { timeout?: number } = {}) =>
+    runCli(['--api-base', API_BASE, ...args], {
+      env, cwd: projectDir, timeout: opts.timeout ?? 60000, enableUpdater: false,
+    });
+
+  before(() => {
+    const login = cli(['login', '--email', EMAIL, '--code', CODE]);
+    assert.equal(login.status, 0, `login failed: ${login.stderr || login.stdout}`);
+
+    const init = cli(['init', projectSlug]);
+    assert.equal(init.status, 0, `init failed: ${init.stderr || init.stdout}`);
+
+    // web-simple gives us a deployable frontend; swap main.js for the probe.
+    const add = cli(['add', 'web-simple']);
+    assert.equal(add.status, 0, `add web-simple failed: ${add.stderr || add.stdout}`);
+    writeFileSync(join(projectDir, 'src', 'js', 'main.js'), PROBE_MAIN_JS);
+
+    const deploy = cli(['deploy', 'dev'], { timeout: 120000 });
+    assert.equal(deploy.status, 0, `deploy failed: ${deploy.stderr || deploy.stdout}`);
+
+    const status = JSON.parse(cli(['status', '--json']).stdout);
+    appUrl = `https://dev.gipity.ai/${status.project.account}/${status.project.slug}/`;
+  });
+
+  after(() => {
+    try { cli(['-y', 'project', 'delete', projectSlug]); } catch { /* ignore */ }
+    try { cli(['logout']); } catch { /* ignore */ }
+    try { rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+    try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  // ── service call ────────────────────────────────────────────────
+
+  it('service call llm/models --get returns the model list (auth via session)', () => {
+    const r = cli(['service', 'call', 'llm/models', '--get']);
+    assert.equal(r.status, 0, `service call failed: ${r.stderr || r.stdout}`);
+    const body = JSON.parse(r.stdout);
+    assert.ok(Array.isArray(body.data?.models) && body.data.models.length > 0, 'expected a non-empty models array');
+  });
+
+  it('service call llm <body> performs a real completion', () => {
+    const r = cli(['service', 'call', 'llm', '{"prompt":"Reply with the single word: pong","max_tokens":16}'], { timeout: 60000 });
+    assert.equal(r.status, 0, `service call llm failed: ${r.stderr || r.stdout}`);
+    const body = JSON.parse(r.stdout);
+    assert.ok(Array.isArray(body.choices) && body.choices.length > 0, 'expected choices in the completion');
+  });
+
+  it('service call --get works on a multi-segment subpath (tts/voices)', () => {
+    const r = cli(['service', 'call', 'tts/voices', '--get']);
+    assert.equal(r.status, 0, `tts/voices failed: ${r.stderr || r.stdout}`);
+    const body = JSON.parse(r.stdout);
+    assert.ok(Array.isArray(body.data?.voices), 'expected a voices array');
+  });
+
+  it('service call rejects invalid JSON before hitting the network', () => {
+    const r = cli(['service', 'call', 'llm', 'not-json']);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr + r.stdout, /not valid JSON/i);
+  });
+
+  it('service call surfaces an unknown service as an error (non-zero exit)', () => {
+    const r = cli(['service', 'call', 'definitely-not-a-service', '{}']);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr + r.stdout, /not found/i);
+  });
+
+  // ── page inspect/screenshot --fake-media ────────────────────────
+
+  it('page inspect --fake-media grants a synthetic mic+cam (getUserMedia resolves)', () => {
+    const r = cli(['page', 'inspect', appUrl, '--fake-media', '--wait', '2500', '--json'], { timeout: 60000 });
+    assert.equal(r.status, 0, `inspect failed: ${r.stderr || r.stdout}`);
+    const bundle = JSON.parse(r.stdout);
+    const consoleText = (bundle.console || []).join(' | ');
+    assert.match(consoleText, /MEDIA_OK audio=[1-9]/, `expected MEDIA_OK, got: ${consoleText}`);
+  });
+
+  it('page inspect WITHOUT --fake-media has no media access (getUserMedia rejects)', () => {
+    const r = cli(['page', 'inspect', appUrl, '--wait', '2500', '--json'], { timeout: 60000 });
+    assert.equal(r.status, 0, `inspect failed: ${r.stderr || r.stdout}`);
+    const bundle = JSON.parse(r.stdout);
+    const consoleText = (bundle.console || []).join(' | ');
+    assert.doesNotMatch(consoleText, /MEDIA_OK/, `fake media leaked into a normal call: ${consoleText}`);
+    assert.match(consoleText, /MEDIA_FAIL/, `expected MEDIA_FAIL, got: ${consoleText}`);
+  });
+
+  it('page screenshot --fake-media still produces a PNG', () => {
+    const r = cli(['page', 'screenshot', appUrl, '--fake-media', '--wait', '2500', '--json'], { timeout: 60000 });
+    assert.equal(r.status, 0, `screenshot failed: ${r.stderr || r.stdout}`);
+    const meta = JSON.parse(r.stdout);
+    assert.ok(meta.screenshots?.length >= 1 && meta.screenshots[0].width > 0, 'expected at least one non-empty screenshot');
+  });
+});

--- a/src/__tests__/cli-e2e-workflow-live.test.ts
+++ b/src/__tests__/cli-e2e-workflow-live.test.ts
@@ -1,0 +1,136 @@
+// Real platform e2e for `gipity workflow` against the live server. Skipped
+// unless GIPITY_E2E=1. This is the non-circular complement to the mocked
+// cli-cmd-workflow tests: it proves the actual server routes exist and behave,
+// exercising the full CRUD + run surface the CLI straddles (it resolves names
+// via the project-scoped tree and mutates via the account-global tree).
+//
+// Cost profile: ~$0.001 (one tiny LLM step when the manual workflow is run;
+// the run is fire-and-forget, the CLI only asserts the trigger was accepted).
+// Dev-bypass auth (914914) with an `ec-` prefixed @914-6.com email.
+//
+//   GIPITY_E2E=1                     enable the suite
+//   GIPITY_E2E_API_BASE=...          default https://a.gipity.ai
+//   GIPITY_E2E_EMAIL=ec-cli-wf@914-6.com
+//   GIPITY_E2E_CODE=914914
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { runCli, makeTmpHome } from './helpers/spawn-cli.js';
+
+const E2E_ENABLED = process.env['GIPITY_E2E'] === '1';
+const API_BASE = process.env['GIPITY_E2E_API_BASE'] ?? 'https://a.gipity.ai';
+const EMAIL = process.env['GIPITY_E2E_EMAIL'] ?? 'ec-cli-wf@914-6.com';
+const CODE = process.env['GIPITY_E2E_CODE'] ?? '914914';
+
+if (E2E_ENABLED && !EMAIL.startsWith('ec')) {
+  throw new Error(`E2E test email must start with "ec" to suppress real outbound mail: got "${EMAIL}"`);
+}
+
+const WF_NAME = `e2e-wf-${Date.now().toString(36)}`;
+const WF_YAML_PATH = 'workflows/e2e.yaml';
+// Minimal manual workflow: one cheap LLM step. `trigger: manual` avoids the
+// per-plan cron-interval limits; no agent_guid is needed (agentId stays null).
+const WF_YAML = `name: ${WF_NAME}
+description: E2E live test workflow (auto-deleted)
+trigger: manual
+steps:
+  - name: greet
+    prompt: "Reply with exactly: ok"
+    model_id: claude-haiku-4-5
+`;
+
+describe('cli-e2e-workflow-live', { skip: !E2E_ENABLED && 'set GIPITY_E2E=1 to run' }, () => {
+  const tmpHome = makeTmpHome();
+  const projectDir = mkdtempSync(join(tmpdir(), 'gipity-e2e-wf-'));
+  const projectSlug = `gip-e2e-wf-${Date.now().toString(36)}`;
+  const env = { HOME: tmpHome };
+
+  const cli = (args: string[], opts: { timeout?: number } = {}) =>
+    runCli(['--api-base', API_BASE, ...args], {
+      env, cwd: projectDir, timeout: opts.timeout ?? 60000, enableUpdater: false,
+    });
+
+  // `workflow create` uses commander's `.requiredOption('--from')`, which a
+  // global value-option (`--api-base <url>`) preceding it mis-parses as
+  // "missing". `init` already persisted apiBase into .gipity.json, so run this
+  // one flagless and let config carry the base. (Real users never pass
+  // --api-base alongside create, so this only affects the test harness.)
+  const cliNoBase = (args: string[], opts: { timeout?: number } = {}) =>
+    runCli(args, { env, cwd: projectDir, timeout: opts.timeout ?? 60000, enableUpdater: false });
+
+  before(() => {
+    const login = cli(['login', '--email', EMAIL, '--code', CODE]);
+    assert.equal(login.status, 0, `login failed: ${login.stderr || login.stdout}`);
+
+    const init = cli(['init', projectSlug]);
+    assert.equal(init.status, 0, `init failed: ${init.stderr || init.stdout}`);
+
+    // Write the workflow YAML and push it to project storage so the server's
+    // create-from-YAML path can read it back out of the project's files.
+    mkdirSync(join(projectDir, 'workflows'), { recursive: true });
+    writeFileSync(join(projectDir, WF_YAML_PATH), WF_YAML);
+    const push = cli(['push', WF_YAML_PATH]);
+    assert.equal(push.status, 0, `push failed: ${push.stderr || push.stdout}`);
+  });
+
+  after(() => {
+    try { cli(['-y', 'workflow', 'delete', WF_NAME]); } catch { /* ignore */ }
+    try { cli(['-y', 'project', 'delete', projectSlug]); } catch { /* ignore */ }
+    try { cli(['logout']); } catch { /* ignore */ }
+    try { rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+    try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('1. create --from <yaml> creates the workflow (POST /workflows, reads project YAML)', () => {
+    const r = cliNoBase(['workflow', 'create', '--from', WF_YAML_PATH]);
+    assert.equal(r.status, 0, `create failed: ${r.stderr || r.stdout}`);
+    assert.match(r.stdout, /Workflow created/);
+  });
+
+  it('2. list shows the workflow (resolves via GET /projects/:guid/workflows)', () => {
+    const r = cli(['workflow', '--json']);
+    assert.equal(r.status, 0, `list failed: ${r.stderr || r.stdout}`);
+    const res = JSON.parse(r.stdout);
+    assert.ok(res.data.some((w: { name: string }) => w.name === WF_NAME), `workflow ${WF_NAME} not in list`);
+  });
+
+  it('3. info <name> resolves by name and shows details (GET /workflows/:guid)', () => {
+    const r = cli(['workflow', 'info', WF_NAME]);
+    assert.equal(r.status, 0, `info failed: ${r.stderr || r.stdout}`);
+    assert.match(r.stdout, new RegExp(`Name:\\s+${WF_NAME}`));
+    assert.match(r.stdout, /Trigger:\s+manual/);
+    assert.match(r.stdout, /greet/); // the step name from the YAML
+  });
+
+  it('4. run <name> triggers the workflow (POST /workflows/:guid/run)', () => {
+    const r = cli(['workflow', 'run', WF_NAME], { timeout: 60000 });
+    assert.equal(r.status, 0, `run failed: ${r.stderr || r.stdout}`);
+    assert.match(r.stdout, new RegExp(`Triggered "${WF_NAME}"`));
+  });
+
+  it('5. runs <name> lists run history (GET /workflows/:guid/runs)', () => {
+    const r = cli(['workflow', 'runs', WF_NAME]);
+    assert.equal(r.status, 0, `runs failed: ${r.stderr || r.stdout}`);
+    assert.doesNotMatch(r.stdout, /undefined/);
+  });
+
+  it('6. enable <name> activates and verifies (PUT /workflows/:guid)', () => {
+    const r = cli(['workflow', 'enable', WF_NAME]);
+    assert.equal(r.status, 0, `enable failed: ${r.stderr || r.stdout}`);
+    assert.match(r.stdout, new RegExp(`Enabled "${WF_NAME}"`));
+  });
+
+  it('7. disable <name> deactivates and verifies (PUT /workflows/:guid)', () => {
+    const r = cli(['workflow', 'disable', WF_NAME]);
+    assert.equal(r.status, 0, `disable failed: ${r.stderr || r.stdout}`);
+    assert.match(r.stdout, new RegExp(`Disabled "${WF_NAME}"`));
+  });
+
+  it('8. delete <name> soft-deletes and verifies it went inactive (DELETE /workflows/:guid)', () => {
+    const r = cli(['workflow', 'delete', WF_NAME]);
+    assert.equal(r.status, 0, `delete failed: ${r.stderr || r.stdout}`);
+    assert.match(r.stdout, new RegExp(`Deleted "${WF_NAME}"`));
+  });
+});

--- a/src/__tests__/relay-ingest-contract.test.ts
+++ b/src/__tests__/relay-ingest-contract.test.ts
@@ -19,14 +19,16 @@ import { mapEventToEntries, type IngestEntry } from '../relay/stream-json.js';
 
 /** Mirror of the server's `entrySchema` in
  *  platform/server/src/routes/remote-sessions.ts. Keep in sync. */
+// Every kind also allows the optional `ts` event-time hint (stored in
+// the server's untrusted `event_at` column).
 const ALLOWED_KEYS_BY_KIND: Record<IngestEntry['kind'], readonly string[]> = {
-  attach:      ['kind', 'session_id', 'cwd', 'source'],
-  prompt:      ['kind', 'prompt'],
-  tool_use:    ['kind', 'tool_use_id', 'tool_name', 'tool_input'],
-  tool_result: ['kind', 'tool_use_id', 'content', 'is_error'],
-  assistant:   ['kind', 'text', 'blocks'],
-  compact:     ['kind', 'trigger'],
-  system:      ['kind', 'content'],
+  attach:      ['kind', 'session_id', 'cwd', 'source', 'ts'],
+  prompt:      ['kind', 'prompt', 'ts'],
+  tool_use:    ['kind', 'tool_use_id', 'tool_name', 'tool_input', 'ts'],
+  tool_result: ['kind', 'tool_use_id', 'tool_name', 'content', 'is_error', 'ts'],
+  assistant:   ['kind', 'text', 'blocks', 'ts'],
+  compact:     ['kind', 'trigger', 'ts'],
+  system:      ['kind', 'content', 'ts'],
 };
 
 /** Sample stream-json events covering every branch of mapEventToEntries.
@@ -69,6 +71,28 @@ describe('ingest contract: daemon entries match server-allowed keys', () => {
       }
     });
   }
+
+  it('tool_result resolves tool_name from the threaded toolNames map', () => {
+    // The tool_result block itself has no name; the daemon threads a
+    // tool_use_id → tool_name map across events so the result can be
+    // denormalized. Replay the assistant (records the name) then the user
+    // (reads it back) through one shared map, as the daemon does.
+    const toolNames = new Map<string, string>();
+    mapEventToEntries(
+      { type: 'assistant', message: { content: [
+        { type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } },
+      ] } },
+      toolNames,
+    );
+    const [result] = mapEventToEntries(
+      { type: 'user', message: { content: [
+        { type: 'tool_result', tool_use_id: 't1', content: 'ok', is_error: false },
+      ] } },
+      toolNames,
+    );
+    assert.equal(result?.kind, 'tool_result');
+    assert.equal((result as { tool_name?: string }).tool_name, 'Bash');
+  });
 
   it('manifest covers every IngestEntry kind in the type union', () => {
     // Compile-time check: TypeScript ensures ALLOWED_KEYS_BY_KIND has an

--- a/src/__tests__/sync.test.ts
+++ b/src/__tests__/sync.test.ts
@@ -38,6 +38,47 @@ describe('plan() - 9-cell decision table', () => {
     assert.equal(p.actions[0].kind, 'download');
   });
 
+  // Read-after-write race guard: a just-pushed local file advances the baseline,
+  // but the remote tree can still serve an OLDER version (stale read). That looks
+  // like unchanged×modified; a blind download would clobber the new local bytes.
+  // A real remote change always carries a strictly newer serverVersion.
+  it('unchanged × modified but remote serverVersion ≤ baseline (stale read) → no download', () => {
+    const p = plan(
+      new Map([['foo', local(100, 'h-new')]]),
+      new Map([['foo', remote('foo', 'h-stale', 4)]]),
+      { foo: baselineOf('h-new', 5) },
+    );
+    assert.equal(p.actions.length, 0);
+  });
+
+  it('unchanged × modified with equal serverVersion (differing sha) → no download', () => {
+    const p = plan(
+      new Map([['foo', local(100, 'h-new')]]),
+      new Map([['foo', remote('foo', 'h-stale', 5)]]),
+      { foo: baselineOf('h-new', 5) },
+    );
+    assert.equal(p.actions.length, 0);
+  });
+
+  it('deleted × modified but stale remote (serverVersion ≤ baseline) → no resurrect', () => {
+    const p = plan(
+      new Map(),
+      new Map([['foo', remote('foo', 'h-stale', 4)]]),
+      { foo: baselineOf('h-cur', 5) },
+    );
+    assert.equal(p.actions.length, 0);
+  });
+
+  it('deleted × modified with a genuinely newer remote → restore (download)', () => {
+    const p = plan(
+      new Map(),
+      new Map([['foo', remote('foo', 'h-newer', 9)]]),
+      { foo: baselineOf('h-cur', 5) },
+    );
+    assert.equal(p.actions.length, 1);
+    assert.equal(p.actions[0].kind, 'download');
+  });
+
   it('unchanged × deleted → delete-local', () => {
     const p = plan(
       new Map([['foo', local(100, 'h1')]]),

--- a/src/capture/sources/claude-code.ts
+++ b/src/capture/sources/claude-code.ts
@@ -25,14 +25,17 @@
  * messages(conversation_id, source_uuid).
  */
 
+// Every entry can carry an optional `ts` - the transcript line's ISO
+// timestamp. The server stores it in the untrusted `messages.event_at`
+// column for per-message timing; `created_at` stays server-authoritative.
 export type IngestEntry =
-  | { kind: 'attach'; session_id: string; cwd?: string; source?: 'startup' | 'resume' | 'clear' | 'compact'; source_uuid?: string }
-  | { kind: 'prompt'; prompt: string; source_uuid?: string }
-  | { kind: 'assistant'; text: string; blocks: any[]; source_uuid?: string }
-  | { kind: 'tool_use'; tool_use_id: string; tool_name: string; tool_input?: unknown; source_uuid?: string }
-  | { kind: 'tool_result'; tool_use_id: string; content: unknown; is_error?: boolean; source_uuid?: string }
-  | { kind: 'compact'; trigger?: string; source_uuid?: string }
-  | { kind: 'system'; content: string; source_uuid?: string };
+  | { kind: 'attach'; session_id: string; cwd?: string; source?: 'startup' | 'resume' | 'clear' | 'compact'; source_uuid?: string; ts?: string }
+  | { kind: 'prompt'; prompt: string; source_uuid?: string; ts?: string }
+  | { kind: 'assistant'; text: string; blocks: any[]; source_uuid?: string; ts?: string }
+  | { kind: 'tool_use'; tool_use_id: string; tool_name: string; tool_input?: unknown; source_uuid?: string; ts?: string }
+  | { kind: 'tool_result'; tool_use_id: string; tool_name?: string; content: unknown; is_error?: boolean; source_uuid?: string; ts?: string }
+  | { kind: 'compact'; trigger?: string; source_uuid?: string; ts?: string }
+  | { kind: 'system'; content: string; source_uuid?: string; ts?: string };
 
 /** Extract joined `{type:'text', text}` blocks into a single string.
  *  The full blocks array is emitted separately so the client can render
@@ -46,8 +49,39 @@ function joinText(content: any[] | undefined): string {
   return parts.join('\n');
 }
 
-/** Map a single parsed transcript line to zero or more ingest entries. */
-export function transcriptLineToEntries(line: any): IngestEntry[] {
+/** Stamp a unique `source_uuid` on every entry parsed from one transcript line.
+ *
+ *  One transcript line yields many entries (an assistant line emits its text
+ *  entry PLUS one tool_use entry per tool call). The server dedupes ingest on
+ *  the partial unique index messages(conversation_id, source_uuid) with
+ *  ON CONFLICT DO NOTHING. If all siblings shared the bare `line.uuid`, the
+ *  first entry (the assistant text) would claim the row and every subsequent
+ *  tool_use would be silently dropped - leaving the later tool_result to land
+ *  as a name-less stub. That bug made 100% of terminal-session tool calls lose
+ *  their tool_name.
+ *
+ *  The primary entry keeps the bare line uuid (so it still dedupes against rows
+ *  written before this fix); each sibling gets a deterministic `#N` suffix.
+ *  Determinism matters: a retried POST re-parses the same line in the same
+ *  order, producing identical suffixes, so dedup still collapses retries. */
+function stampEntries(entries: IngestEntry[], lineUuid: string, lineTs?: string): IngestEntry[] {
+  return entries.map((e, i) => ({
+    ...e,
+    source_uuid: i === 0 ? lineUuid : `${lineUuid}#${i}`,
+    ...(lineTs ? { ts: lineTs } : {}),
+  }));
+}
+
+/** Map a single parsed transcript line to zero or more ingest entries.
+ *
+ *  `toolNames` (optional) is a per-transcript `tool_use_id → tool_name`
+ *  map threaded across lines by `parseTranscript`: an assistant line
+ *  records each tool call's name into it, and the later user line that
+ *  carries the paired `tool_result` reads the name back out. This lets
+ *  the server denormalize `tool_name` onto the tool row even when the
+ *  result lands as a stub (the tool_use row missing/deduped). The
+ *  `tool_result` block itself never carries the name. */
+export function transcriptLineToEntries(line: any, toolNames?: Map<string, string>): IngestEntry[] {
   if (!line || typeof line !== 'object') return [];
   if (typeof line.type !== 'string') return [];
   if (typeof line.uuid !== 'string' || !line.uuid) return [];
@@ -57,13 +91,14 @@ export function transcriptLineToEntries(line: any): IngestEntry[] {
   if (line.toolUseResult && !line.message) return [];
 
   const srcUuid: string = line.uuid;
+  const lineTs: string | undefined = typeof line.timestamp === 'string' ? line.timestamp : undefined;
   const msg = line.message ?? {};
 
   if (line.type === 'user') {
     const content = msg.content;
     if (typeof content === 'string') {
       if (!content) return [];
-      return [{ kind: 'prompt', prompt: content, source_uuid: srcUuid }];
+      return stampEntries([{ kind: 'prompt', prompt: content }], srcUuid, lineTs);
     }
     if (Array.isArray(content)) {
       const out: IngestEntry[] = [];
@@ -72,17 +107,17 @@ export function transcriptLineToEntries(line: any): IngestEntry[] {
           out.push({
             kind: 'tool_result',
             tool_use_id: b.tool_use_id,
+            tool_name: toolNames?.get(b.tool_use_id),
             content: b.content ?? null,
             is_error: Boolean(b.is_error),
-            source_uuid: srcUuid,
           });
         } else if (b?.type === 'text' && typeof b.text === 'string' && b.text) {
           // A user message with raw text blocks (rare - first-turn preamble
           // is sometimes split this way). Treat like a prompt.
-          out.push({ kind: 'prompt', prompt: b.text, source_uuid: srcUuid });
+          out.push({ kind: 'prompt', prompt: b.text });
         }
       }
-      return out;
+      return stampEntries(out, srcUuid, lineTs);
     }
     return [];
   }
@@ -92,20 +127,21 @@ export function transcriptLineToEntries(line: any): IngestEntry[] {
     const text = joinText(content);
     const out: IngestEntry[] = [];
     if (text || content.length) {
-      out.push({ kind: 'assistant', text, blocks: content, source_uuid: srcUuid });
+      out.push({ kind: 'assistant', text, blocks: content });
     }
     for (const block of content) {
       if (block?.type === 'tool_use' && typeof block.id === 'string') {
+        const toolName = typeof block.name === 'string' ? block.name : 'tool';
+        toolNames?.set(block.id, toolName);
         out.push({
           kind: 'tool_use',
           tool_use_id: block.id,
-          tool_name: typeof block.name === 'string' ? block.name : 'tool',
+          tool_name: toolName,
           tool_input: block.input ?? null,
-          source_uuid: srcUuid,
         });
       }
     }
-    return out;
+    return stampEntries(out, srcUuid, lineTs);
   }
 
   // Other envelope types (system notes, hook-emitted, …) - not captured.
@@ -128,6 +164,11 @@ export function parseTranscript(
   let seenWatermark = afterUuid === null;
   let lastUuid: string | null = afterUuid;
   const out: IngestEntry[] = [];
+  // tool_use_id → tool_name, accumulated across lines so a later
+  // tool_result can be denormalized with its tool's name. Built from the
+  // whole file (including pre-watermark lines) so a result whose tool_use
+  // was forwarded in an earlier sweep still resolves its name.
+  const toolNames = new Map<string, string>();
 
   for (const raw of content.split('\n')) {
     const line = raw.trim();
@@ -135,12 +176,21 @@ export function parseTranscript(
     let parsed: any;
     try { parsed = JSON.parse(line); } catch { continue; }
 
+    // Record tool names from every assistant line we scan, even before the
+    // watermark - the map is read-only side state, it doesn't emit entries.
     if (!seenWatermark) {
+      if (Array.isArray(parsed?.message?.content)) {
+        for (const block of parsed.message.content) {
+          if (block?.type === 'tool_use' && typeof block.id === 'string') {
+            toolNames.set(block.id, typeof block.name === 'string' ? block.name : 'tool');
+          }
+        }
+      }
       if (parsed?.uuid === afterUuid) seenWatermark = true;
       continue;
     }
 
-    const entries = transcriptLineToEntries(parsed);
+    const entries = transcriptLineToEntries(parsed, toolNames);
     if (entries.length) {
       for (const e of entries) out.push(e);
       lastUuid = parsed.uuid;

--- a/src/commands/page-eval.ts
+++ b/src/commands/page-eval.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { post } from '../api.js';
+import { post, get, ApiError } from '../api.js';
 import { brand, bold, muted } from '../colors.js';
 import { run } from '../helpers/index.js';
 
@@ -7,6 +7,41 @@ interface EvalResult {
   url: string;
   result: string;
   truncated: boolean;
+}
+
+type EvalJobRecord =
+  | { status: 'running' }
+  | ({ status: 'done' } & EvalResult)
+  | { status: 'error'; httpStatus: number; code: string; reason: string };
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Poll the async eval job until it finishes. Eval runs server-side as a
+ *  short-lived job (so a long --wait can't trip the gateway idle timeout);
+ *  we submit, then poll the result out of the job store. */
+async function pollEvalResult(evalJobId: string, waitMs: number): Promise<EvalResult> {
+  // Generous client budget: the server work is bounded by --wait plus browser
+  // open/settle overhead; give it that plus headroom before giving up.
+  const deadline = Date.now() + waitMs + 60_000;
+  let missCount = 0;
+  while (Date.now() < deadline) {
+    let rec: EvalJobRecord;
+    try {
+      rec = (await get<{ data: EvalJobRecord }>(`/tools/browser/eval/${evalJobId}`)).data;
+    } catch (err) {
+      // A 404 right after submit can happen if the record hasn't landed yet;
+      // tolerate a few, then treat a persistent 404 as the job being gone.
+      if (err instanceof ApiError && err.statusCode === 404 && missCount++ < 3) {
+        await sleep(500);
+        continue;
+      }
+      throw err;
+    }
+    if (rec.status === 'done') return rec;
+    if (rec.status === 'error') throw new ApiError(rec.httpStatus, rec.code, rec.reason);
+    await sleep(1000);
+  }
+  throw new ApiError(504, 'EVAL_TIMEOUT', 'Eval did not finish in time; narrow the expression or lower --wait');
 }
 
 // The long-tail escape hatch alongside `page inspect`'s fixed bundle: when the
@@ -18,13 +53,21 @@ export const pageEvalCommand = new Command('eval')
   .argument('<url>', 'URL to load')
   .argument('<expr>', 'JavaScript expression to evaluate in page context (result is JSON-serialized)')
   .option('--wait <ms>', 'Sleep this many ms after DOMContentLoaded before evaluating (lets late async work settle)', '500')
+  .option('--wait-for <selector>', 'Wait until this CSS selector appears before evaluating (deterministic; replaces --wait)')
+  .option('--wait-timeout <ms>', 'Max ms to wait for --wait-for before giving up', '5000')
   .option('--json', 'Output as JSON')
   .action((url: string, expr: string, opts) => run('Page eval', async () => {
     const parsedWait = parseInt(opts.wait, 10);
     const waitMs = Number.isFinite(parsedWait) && parsedWait >= 0 ? parsedWait : 500;
+    const parsedTimeout = parseInt(opts.waitTimeout, 10);
+    const waitForTimeoutMs = Number.isFinite(parsedTimeout) && parsedTimeout >= 0 ? parsedTimeout : 5000;
 
-    const res = await post<{ data: EvalResult }>('/tools/browser/eval', { url, expr, waitMs });
-    const d = res.data;
+    const kickoff = await post<{ data: { evalJobId: string } }>('/tools/browser/eval', {
+      url, expr, waitMs,
+      waitForSelector: opts.waitFor || undefined,
+      waitForTimeoutMs: opts.waitFor ? waitForTimeoutMs : undefined,
+    });
+    const d = await pollEvalResult(kickoff.data.evalJobId, waitMs);
 
     if (opts.json) {
       console.log(JSON.stringify(d));

--- a/src/commands/page-inspect.ts
+++ b/src/commands/page-inspect.ts
@@ -44,9 +44,12 @@ export const pageInspectCommand = new Command('inspect')
   .description('Inspect a web page (console, failed resources, timing, layout overflow)')
   .argument('<url>', 'URL to inspect')
   .option('--wait <ms>', 'Sleep this many ms after DOMContentLoaded before capturing (lets late async/LCP work settle)', '500')
+  .option('--wait-for <selector>', 'Wait until this CSS selector appears before capturing (deterministic; replaces --wait)')
+  .option('--wait-timeout <ms>', 'Max ms to wait for --wait-for before giving up', '5000')
   .option('--json', 'Output as JSON')
   .option('--no-truncate', 'Show full URLs instead of truncating long ones with middle-ellipsis')
   .option('--all', 'Include render-blocking, large resources, oversized images, overflow culprits, and LCP detail')
+  .option('--fake-media', 'Grant a synthetic microphone + camera and auto-accept the getUserMedia prompt, so voice/camera apps run headlessly (audio is a built-in tone, not real speech)')
   // Hidden redirect: agents reach for `page inspect --screenshot`. We don't take
   // an image here (`page screenshot` is the single path for that) — just point there.
   .addOption(new Option('--screenshot [path]', 'Capture a screenshot').hideHelp())
@@ -59,12 +62,19 @@ export const pageInspectCommand = new Command('inspect')
     return run('Page inspect', async () => {
     const parsedWait = parseInt(opts.wait, 10);
     const waitMs = Number.isFinite(parsedWait) && parsedWait >= 0 ? parsedWait : 500;
+    const parsedTimeout = parseInt(opts.waitTimeout, 10);
+    const waitForTimeoutMs = Number.isFinite(parsedTimeout) && parsedTimeout >= 0 ? parsedTimeout : 5000;
     const truncate = opts.truncate !== false;
     const showAll = opts.all === true;
 
     const res = await post<{ data: DebugBundle }>(
       `/tools/browser/inspect`,
-      { url, waitMs },
+      {
+        url, waitMs,
+        waitForSelector: opts.waitFor || undefined,
+        waitForTimeoutMs: opts.waitFor ? waitForTimeoutMs : undefined,
+        fakeMedia: opts.fakeMedia || undefined,
+      },
     );
 
     const b = res.data;
@@ -102,11 +112,28 @@ export const pageInspectCommand = new Command('inspect')
     }
 
     // ── Failed Resources ──
-    if (b.failedResources?.length > 0) {
-      console.log(`\n  ${clrError(`Failed resources (${b.failedResources.length}):`)}`);
-      for (const r of b.failedResources) {
+    // Browsers auto-request /favicon.ico at the site root for every page, so a
+    // 404 there isn't a resource the page actually links — it's noise on any
+    // app served under a subpath. Split that implicit request out of the failure
+    // list into a harmless note rather than flagging it as an error.
+    const isImplicitFavicon = (entry: string): boolean => {
+      const urlPart = entry.replace(/\s*\([^)]*\)\s*$/, '');
+      try {
+        return new URL(urlPart).pathname === '/favicon.ico';
+      } catch {
+        return false;
+      }
+    };
+    const failed = (b.failedResources || []).filter((r) => !isImplicitFavicon(r));
+    const rootFaviconMissing = (b.failedResources || []).some(isImplicitFavicon);
+    if (failed.length > 0) {
+      console.log(`\n  ${clrError(`Failed resources (${failed.length}):`)}`);
+      for (const r of failed) {
         console.log(`    ${clrError(r)}`);
       }
+    }
+    if (rootFaviconMissing) {
+      console.log(`\n  ${muted('No root /favicon.ico (browsers request this automatically; harmless for app pages served under a subpath)')}`);
     }
 
     // ── Layout (horizontal overflow) ──

--- a/src/commands/page-screenshot.ts
+++ b/src/commands/page-screenshot.ts
@@ -132,6 +132,7 @@ export const pageScreenshotCommand = new Command('screenshot')
   .option('--device <names>', `Viewport preset(s): ${Object.keys(DEVICE_PRESETS).join(', ')} (comma-separated or repeat flag)`, appendOption, [] as string[])
   .option('--viewport <dims>', 'Raw viewport(s): WxH or WxH@dpr (comma-separated or repeat flag)', appendOption, [] as string[])
   .option('--no-reload-between', 'Skip reload between viewports (faster, lower fidelity - only safe for static pages)')
+  .option('--fake-media', 'Grant a synthetic microphone + camera and auto-accept the getUserMedia prompt, so voice/camera apps render headlessly (audio is a built-in tone, not real speech)')
   .option('--json', 'Output JSON metadata instead of a friendly summary')
   .addOption(new Option('--wait <ms>', 'Alias for --post-load-delay').hideHelp())
   .action((url: string, opts) => run('Page screenshot', async () => {
@@ -161,6 +162,7 @@ export const pageScreenshotCommand = new Command('screenshot')
       full: !!opts.full,
       reloadBetween: opts.reloadBetween !== false,
       ...(userSpecifiedViewports ? { viewports: customViewports } : {}),
+      ...(opts.fakeMedia ? { fakeMedia: true } : {}),
     };
 
     const entries = await postForTarEntries('/tools/browser/screenshot', body);

--- a/src/commands/page-test.ts
+++ b/src/commands/page-test.ts
@@ -1,0 +1,96 @@
+import { Command } from 'commander';
+import { post } from '../api.js';
+import { brand, bold, muted, warning, success, error as clrError } from '../colors.js';
+import { run } from '../helpers/index.js';
+
+// Only the fields we read off the inspect bundle.
+interface DebugBundle {
+  console?: string[];
+}
+
+interface ClientResult {
+  i: number;
+  lines: string[];
+  error?: string;
+}
+
+// Lines worth surfacing - genuine errors and crash signatures, not benign warnings.
+const BAD = /^error:|uncaught|unhandled|message handler error|\bcrash|RuntimeError/i;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Run one passive page load via the inspect endpoint and return its console. */
+async function inspectClient(url: string, waitMs: number, i: number): Promise<ClientResult> {
+  try {
+    const res = await post<{ data: DebugBundle }>('/tools/browser/inspect', { url, waitMs });
+    return { i, lines: res.data.console ?? [] };
+  } catch (err) {
+    return { i, lines: [], error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// Headless multi-client realtime check: spin N staggered browser clients at a
+// deployed URL and flag error/crash lines across their consoles. The verifier
+// for realtime apps (host election, presence, world sync, reconnection) -
+// promotes the internal multi-client-test script to a first-class command.
+//
+// Passive page loads only: each client just loads the URL and settles. An app
+// that connects to realtime only after a user action (e.g. a lobby that joins
+// on a button press) needs a URL-param test mode so the load alone exercises
+// the path - see the app-realtime skill.
+export const pageTestCommand = new Command('test')
+  .description('Multi-client realtime check: load a URL in N staggered headless clients, flag console errors')
+  .argument('<url>', 'Deployed URL to load in every client')
+  .option('--clients <n>', 'Number of headless clients to launch', '2')
+  .option('--stagger <s>', 'Seconds between client starts (client 0 settles first, e.g. as host)', '12')
+  .option('--wait <ms>', 'Milliseconds each client stays open after load (max 30000)', '24000')
+  .option('--json', 'Output as JSON')
+  .action((url: string, opts) => run('Page test', async () => {
+    const clients = Math.max(1, parseInt(opts.clients, 10) || 2);
+    const stagger = Math.max(0, parseInt(opts.stagger, 10) || 0);
+    const wait = Math.min(30000, Math.max(2000, parseInt(opts.wait, 10) || 24000));
+
+    if (!opts.json) {
+      console.log(`\n${brand('Page test')} ${bold(url)}`);
+      console.log(`  ${muted(`${clients} client(s), stagger ${stagger}s, ${wait}ms open each`)}\n`);
+    }
+
+    const runs: Promise<ClientResult>[] = [];
+    for (let i = 0; i < clients; i++) {
+      runs.push((async () => {
+        await sleep(i * stagger * 1000);
+        if (!opts.json) console.log(`  ${muted(`client ${i}${i === 0 ? ' (first)' : ''} starting`)}`);
+        return inspectClient(url, wait, i);
+      })());
+    }
+    const results = (await Promise.all(runs)).sort((a, b) => a.i - b.i);
+
+    let problems = 0;
+    for (const r of results) {
+      if (r.error) problems++;
+      else problems += r.lines.filter((l) => BAD.test(l)).length;
+    }
+
+    if (opts.json) {
+      console.log(JSON.stringify({ url, clients, stagger, wait, problems, results }));
+      if (problems > 0) process.exitCode = 1;
+      return;
+    }
+
+    for (const r of results) {
+      console.log(`\n${bold(`=== client ${r.i}${r.i === 0 ? ' (first)' : ''} ===`)}`);
+      if (r.error) { console.log(`  ${clrError(`page inspect failed: ${r.error}`)}`); continue; }
+      if (r.lines.length === 0) { console.log(`  ${muted('(no console output)')}`); continue; }
+      for (const line of r.lines) {
+        const bad = BAD.test(line);
+        console.log(`  ${bad ? warning('⚠ ' + line) : ' ' + line}`);
+      }
+    }
+
+    console.log(
+      problems === 0
+        ? `\n${success('✓ no error/crash lines across all clients')}\n`
+        : `\n${clrError(`⚠ ${problems} error/crash line(s) flagged above`)}\n`,
+    );
+    if (problems > 0) process.exitCode = 1;
+  }));

--- a/src/commands/page.ts
+++ b/src/commands/page.ts
@@ -2,16 +2,18 @@ import { Command } from 'commander';
 import { pageInspectCommand } from './page-inspect.js';
 import { pageScreenshotCommand } from './page-screenshot.js';
 import { pageEvalCommand } from './page-eval.js';
+import { pageTestCommand } from './page-test.js';
 
 // Parent namespace grouping the page/browser diagnostics under one command:
-//   gipity page inspect | eval | screenshot
+//   gipity page inspect | eval | screenshot | test
 // Each subcommand is canonical for its capability; the namespace keeps the
 // top-level surface lean and makes the siblings discoverable via `page --help`.
 export const pageCommand = new Command('page')
-  .description('Inspect, evaluate, and screenshot web pages (page inspect | eval | screenshot)')
+  .description('Inspect, evaluate, screenshot, and multi-client test web pages (page inspect | eval | screenshot | test)')
   .addCommand(pageInspectCommand)
   .addCommand(pageEvalCommand)
-  .addCommand(pageScreenshotCommand);
+  .addCommand(pageScreenshotCommand)
+  .addCommand(pageTestCommand);
 
 // No subcommand → show help instead of commander's terse error.
 pageCommand.action(() => {

--- a/src/commands/service.ts
+++ b/src/commands/service.ts
@@ -1,0 +1,56 @@
+import { Command } from 'commander';
+import { get, post } from '../api.js';
+import { requireConfig } from '../config.js';
+import { bold, muted } from '../colors.js';
+import { run } from '../helpers/index.js';
+
+/** Known app-service endpoints, shown by `gipity service list` and used to
+ *  give a helpful hint on typos. POST endpoints take a JSON body; GET
+ *  endpoints (model/voice listings) are reached with `--get`. */
+const SERVICES: Array<{ name: string; method: 'POST' | 'GET'; desc: string }> = [
+  { name: 'llm', method: 'POST', desc: 'Chat completion ({ prompt | messages, model?, ... })' },
+  { name: 'llm/models', method: 'GET', desc: 'List available LLM models' },
+  { name: 'image', method: 'POST', desc: 'Generate an image ({ prompt, provider?, size? })' },
+  { name: 'image/models', method: 'GET', desc: 'List image providers/models' },
+  { name: 'tts', method: 'POST', desc: 'Text-to-speech ({ text, voice?, ... })' },
+  { name: 'tts/voices', method: 'GET', desc: 'List TTS voices' },
+  { name: 'sound', method: 'POST', desc: 'Sound effect ({ prompt, duration_seconds? })' },
+  { name: 'music', method: 'POST', desc: 'Music generation ({ prompt, duration_seconds? })' },
+  { name: 'video', method: 'POST', desc: 'Video generation ({ prompt, ... })' },
+  { name: 'location/ip', method: 'POST', desc: 'IP geolocation ({ ip? })' },
+  { name: 'location/geocode', method: 'POST', desc: 'Reverse geocode ({ lat, lon })' },
+];
+
+export const serviceCommand = new Command('service')
+  .description('Call a Gipity app service (LLM, image, music, TTS, ...)');
+
+serviceCommand
+  .command('list')
+  .description('List callable app services')
+  .action(() => run('Services', async () => {
+    requireConfig();
+    for (const s of SERVICES) {
+      console.log(`${bold(s.name)} ${muted(`[${s.method}]`)}\n  ${muted(s.desc)}`);
+    }
+    console.log(muted('\nCall with: gipity service call <name> \'{"json":"body"}\''));
+  }));
+
+serviceCommand
+  .command('call <name> [body]')
+  .description('Call an app service by name (e.g. llm, image, music). Uses your logged-in session - no token wrangling.')
+  .option('--data <json>', 'JSON request body (alternative to the positional [body])')
+  .option('--get', 'Issue a GET (for listing endpoints like llm/models, tts/voices)')
+  .option('--json', 'Output compact JSON')
+  .action((name: string, bodyArg: string | undefined, opts) => run('Call', async () => {
+    const config = requireConfig();
+    // Encode each path segment but preserve the `/` separators so subpaths
+    // like `location/geocode` and `llm/models` resolve correctly.
+    const path = name.split('/').map(encodeURIComponent).join('/');
+    const url = `/api/${config.projectGuid}/services/${path}`;
+
+    const res = opts.get
+      ? await get<unknown>(url)
+      : await post<unknown>(url, JSON.parse(bodyArg || opts.data || '{}'));
+
+    console.log(opts.json ? JSON.stringify(res) : JSON.stringify(res, null, 2));
+  }));

--- a/src/commands/workflow.ts
+++ b/src/commands/workflow.ts
@@ -197,24 +197,21 @@ workflowCommand
   }));
 
 // Resolve a workflow by name within the linked project (like `gipity fn`), or
-// by short_guid anywhere. Names are unique per active project workflow (DB
-// constraint), so a bare name in this project is unambiguous; the same name in
-// another project is a different workflow and simply isn't matched here.
+// by short_guid anywhere. Uses the single account-wide `/workflows` list (the
+// same endpoint the bare `workflow` list hits) so the whole command stays on
+// one route tree. Names are unique per active project workflow (DB constraint),
+// so we scope by the current project's slug; a short_guid resolves anywhere.
 async function resolveWorkflow(name: string): Promise<WorkflowData> {
-  const { projectGuid } = requireConfig();
-  const res = await get<{ data: WorkflowData[] }>(`/projects/${projectGuid}/workflows`);
-  const list = res.data ?? [];
+  const { projectSlug } = requireConfig();
+  const res = await get<WorkflowListResponse>('/workflows');
+  const all = res.data ?? [];
 
-  // Exact short_guid match wins — unambiguous override.
-  const byGuid = list.find(w => w.short_guid === name);
+  // Exact short_guid match wins anywhere — unambiguous override.
+  const byGuid = all.find(w => w.short_guid === name);
   if (byGuid) return byGuid;
 
-  const byName = list.filter(w => w.name === name);
+  const byName = all.filter(w => w.project_slug === projectSlug && w.name === name);
   if (byName.length === 0) {
-    // Fall back to a global short_guid lookup (e.g. account-level workflows).
-    const all = await get<{ data: WorkflowData[] }>('/workflows');
-    const global = (all.data ?? []).find(w => w.short_guid === name);
-    if (global) return global;
     console.error(clrError(`Workflow "${name}" not found in this project.`));
     process.exit(1);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { logsCommand } from './commands/logs.js';
 import { pageCommand } from './commands/page.js';
 import { recordsCommand } from './commands/records.js';
 import { fnCommand } from './commands/fn.js';
+import { serviceCommand } from './commands/service.js';
 import { jobCommand } from './commands/job.js';
 import { rbacCommand } from './commands/rbac.js';
 import { auditCommand } from './commands/audit.js';
@@ -93,12 +94,19 @@ function configureHelp(cmd: Command): void {
 
 const program = new Command();
 
+// Global value-options (`--api-base <url>`) are only meaningful before the
+// subcommand. Without this, commander interleaves program + subcommand option
+// parsing and mis-reads a subcommand's `.requiredOption()` as missing when a
+// global value-option precedes it (e.g. `gipity --api-base X workflow create
+// --from Y`). enablePositionalOptions draws the boundary at the first command.
+program.enablePositionalOptions();
+
 // ── Command groups (logical ordering within each) ──────────────────────
 const commonGroup      = [skillCommand, projectCommand, addCommand, deployCommand];
 const connectGroup     = [claudeCommand, relayCommand];
 const projectGroup     = [domainCommand, statusCommand, initCommand];
 const filesGroup       = [fileCommand, syncCommand, pushCommand, uploadCommand];
-const appBuildingGroup = [testCommand, fnCommand, jobCommand, dbCommand, logsCommand, workflowCommand, realtimeCommand, rbacCommand, auditCommand, recordsCommand];
+const appBuildingGroup = [testCommand, fnCommand, serviceCommand, jobCommand, dbCommand, logsCommand, workflowCommand, realtimeCommand, rbacCommand, auditCommand, recordsCommand];
 const utilitiesGroup   = [pageCommand, sandboxCommand, generateCommand, emailCommand, gmailCommand, locationCommand];
 const agentGroup       = [chatCommand, memoryCommand, agentCommand, approvalCommand];
 const setupGroup       = [loginCommand, logoutCommand, creditsCommand, planCommand, doctorCommand, updateCommand, uninstallCommand];

--- a/src/knowledge.ts
+++ b/src/knowledge.ts
@@ -37,7 +37,7 @@ export const SKILLS_CONTENT = `# Gipity Integration
 
 Gipity is the cloud platform your project runs on - hosting, databases, deployment, file storage, code execution, workflows, and monitoring. Gip is the cloud agent that runs on Gipity.
 
-This session is connected to a Gipity project. Prefer the cheapest option that works - CLI and sandbox are instant and free, app services are runtime HTTP calls, \`gipity chat\` burns LLM tokens:
+Prefer the cheapest option that works - CLI and sandbox are instant and free, app services are runtime HTTP calls, \`gipity chat\` burns LLM tokens:
 
 1. CLI commands (fast, no agent overhead). The \`gipity\` CLI covers add, deploy, db, fn, logs, browser, sync, memory, skill, and more. All commands support \`--json\`.
 2. Cloud sandbox via \`gipity sandbox run\` - Docker container with pre-installed tools for media (ffmpeg, ImageMagick, sox), documents (pandoc, LibreOffice), and data (pandas, matplotlib, sqlite3). Run \`gipity skill read sandbox-tools\` for the full toolkit. No network from inside the sandbox - fetch what you need before sending it in.
@@ -48,7 +48,7 @@ You are the developer. Write files in this directory - they auto-sync to Gipity 
 
 ## Use first-party services before reaching outside
 
-Gipity ships its own services for things apps usually pull from a third party - auth, location and geocoding, LLM, image/audio/video generation, transcription, file uploads, realtime. Before you call an external API or add an npm package for one of these, run \`gipity skill list\` and look for a matching skill. First-party services need no API keys, cost less, and keep user data off third parties. Reach outside only when the catalog genuinely has no equivalent - and say so when you do.
+Gipity ships first-party services for what apps usually pull from third parties - auth, location/geocoding, LLM, image/audio/video generation, transcription, file uploads, realtime. Before calling an external API or adding an npm package for one of these, check \`gipity skill list\` for a match. First-party services need no API keys, cost less, and keep data in-house. Reach outside only when the catalog has no equivalent - and say so when you do.
 
 ## When to add a template
 

--- a/src/relay/daemon.ts
+++ b/src/relay/daemon.ts
@@ -974,13 +974,22 @@ export async function spawnGipityClaude(
     // as they arrive. That's the live-streaming path - every assistant
     // message and tool call appears in the web CLI within a second of
     // Claude emitting it.
+    // Per-dispatch tool_use_id → tool_name map so a `tool_result` event can
+    // be denormalized with its tool's name (the result block omits it).
+    const toolNames = new Map<string, string>();
     const splitter = createLineSplitter((line) => {
       const evt = parseEvent(line, (reason, snippet) => {
         log('warn', 'stream-json parse skipped line', { id: d.short_guid, reason, snippet });
       });
       if (!evt) return;
-      const entries = mapEventToEntries(evt);
+      const entries = mapEventToEntries(evt, toolNames);
       if (entries.length === 0) return;
+      // Stamp the read time as the event-time hint (event_at). Stream-json
+      // carries no per-event timestamp; the daemon reads events as Claude
+      // emits them, so receipt time is a close, per-event proxy - far
+      // better than the single flush-time created_at on the whole batch.
+      const ts = new Date().toISOString();
+      for (const e of entries) e.ts = ts;
       // Fire-and-forget POST but tracked so the drain on exit can
       // `allSettled` the set before we claim the spawn is done.
       const p: Promise<void> = postIngest(d.conversation_guid, entries)

--- a/src/relay/stream-json.ts
+++ b/src/relay/stream-json.ts
@@ -14,17 +14,18 @@
 
 // ─── Ingest wire format (matches server's /ingest Zod schema) ──────────
 
-// Note: no `ts` field. The server uses `messages.created_at = NOW()` as
-// the authoritative timestamp; a client-supplied hint isn't read and is
-// now rejected by the strict ingest schema.
+// `ts` is an optional informational hint (the daemon stamps it at the
+// moment it reads the event off the stream). The server stores it in the
+// untrusted `messages.event_at` column for per-event timing; `created_at`
+// stays server-authoritative (NOW()), so a hint can't backdate history.
 export type IngestEntry =
-  | { kind: 'attach'; session_id: string; cwd?: string; source?: 'startup' | 'resume' | 'clear' | 'compact' }
-  | { kind: 'prompt'; prompt: string }
-  | { kind: 'assistant'; text: string; blocks: any[] }
-  | { kind: 'tool_use'; tool_use_id: string; tool_name: string; tool_input?: unknown }
-  | { kind: 'tool_result'; tool_use_id: string; content: unknown; is_error?: boolean }
-  | { kind: 'compact'; trigger?: string }
-  | { kind: 'system'; content: string };
+  | { kind: 'attach'; session_id: string; cwd?: string; source?: 'startup' | 'resume' | 'clear' | 'compact'; ts?: string }
+  | { kind: 'prompt'; prompt: string; ts?: string }
+  | { kind: 'assistant'; text: string; blocks: any[]; ts?: string }
+  | { kind: 'tool_use'; tool_use_id: string; tool_name: string; tool_input?: unknown; ts?: string }
+  | { kind: 'tool_result'; tool_use_id: string; tool_name?: string; content: unknown; is_error?: boolean; ts?: string }
+  | { kind: 'compact'; trigger?: string; ts?: string }
+  | { kind: 'system'; content: string; ts?: string };
 
 // ─── Stream-json event shapes ──────────────────────────────────────────
 // Only the fields we actually read are typed - everything else is passed
@@ -134,8 +135,14 @@ function joinAssistantText(content: any[] | undefined): string {
  *  assistant event may yield one `assistant` entry AND one `tool_use`
  *  entry per tool_use block within it (server persists each tool call
  *  as its own `role='tool'` row, then updates it when the matching
- *  `tool_result` arrives). */
-export function mapEventToEntries(evt: StreamJsonEvent): IngestEntry[] {
+ *  `tool_result` arrives).
+ *
+ *  `toolNames` (optional) is a per-dispatch `tool_use_id → tool_name`
+ *  map threaded across events by the daemon: assistant events record
+ *  each tool call's name, the later user event with the paired
+ *  `tool_result` reads it back so the server can denormalize `tool_name`
+ *  onto the tool row even when the result lands as a stub. */
+export function mapEventToEntries(evt: StreamJsonEvent, toolNames?: Map<string, string>): IngestEntry[] {
   const out: IngestEntry[] = [];
 
   if (evt.type === 'system' && (evt as StreamJsonSystemInit).subtype === 'init') {
@@ -153,10 +160,12 @@ export function mapEventToEntries(evt: StreamJsonEvent): IngestEntry[] {
     }
     for (const block of content) {
       if (block?.type === 'tool_use' && typeof block.id === 'string') {
+        const toolName = typeof block.name === 'string' ? block.name : 'tool';
+        toolNames?.set(block.id, toolName);
         out.push({
           kind: 'tool_use',
           tool_use_id: block.id,
-          tool_name: typeof block.name === 'string' ? block.name : 'tool',
+          tool_name: toolName,
           tool_input: block.input ?? null,
         });
       }
@@ -172,6 +181,7 @@ export function mapEventToEntries(evt: StreamJsonEvent): IngestEntry[] {
         out.push({
           kind: 'tool_result',
           tool_use_id: block.tool_use_id,
+          tool_name: toolNames?.get(block.tool_use_id),
           content: block.content ?? null,
           is_error: Boolean(block.is_error),
         });

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -69,6 +69,7 @@ export const PERMISSIONS_SETTINGS = {
       'Bash(gipity file versions *)',
       'Bash(gipity records *)',
       'Bash(gipity fn *)',
+      'Bash(gipity service *)',
       'Bash(gipity rbac *)',
       'Bash(gipity audit *)',
       'Bash(gipity generate *)',

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -407,8 +407,15 @@ export function plan(
     }
     // unchanged × unchanged → noop
     if (lSide === 'unchanged' && rSide === 'unchanged') continue;
-    // unchanged × modified → download
+    // unchanged × modified → download, but ONLY if the remote genuinely advanced.
+    // Guards a read-after-write race: right after a local write+push, the push can
+    // advance the local baseline to the new version while the remote tree API still
+    // serves the OLD bytes (stale read). That makes remote look "modified" vs an
+    // already-updated baseline, and a blind download would silently clobber the
+    // just-written local file with a stale older version. A real remote change
+    // always carries a strictly newer serverVersion; an equal/older one is stale.
     if (lSide === 'unchanged' && rSide === 'modified') {
+      if (B && R!.serverVersion <= B.serverVersion) continue;
       actions.push({ path, kind: 'download', remoteSize: R!.size });
       continue;
     }
@@ -461,8 +468,11 @@ export function plan(
       actions.push({ path, kind: 'delete-remote', remoteSize: R!.size, expectedServerVersion: B!.serverVersion });
       continue;
     }
-    // deleted × modified → remote wins, restore locally
+    // deleted × modified → remote wins, restore locally — but only if the remote
+    // actually advanced past the baseline. A stale (older/equal) remote read must
+    // not resurrect a file the user intentionally deleted.
     if (lSide === 'deleted' && rSide === 'modified') {
+      if (B && R!.serverVersion <= B.serverVersion) continue;
       actions.push({
         path, kind: 'download', remoteSize: R!.size,
         reason: 'local deleted but remote modified - remote preserved',


### PR DESCRIPTION
## Rationale

`page inspect` reported `Failed resources (1): https://dev.gipity.ai/favicon.ico (404)`, which is the browser's automatic root favicon request, not a resource the page actually links. The agent had to spend output explaining it away as cosmetic, and this noise recurs on essentially every static page served under a subpath.

## Change

In the `page inspect` failed-resources collector (`src/commands/page-inspect.ts`), the implicit top-level `/favicon.ico` request is now split out of the failure list. Entries whose URL path is `/favicon.ico` are excluded from the `Failed resources (...)` error block and surfaced instead as a harmless note:

> No root /favicon.ico (browsers request this automatically; harmless for app pages served under a subpath)

Real failed resources are still reported as errors. The `--json` output continues to return the raw inspect bundle unchanged. Added two `cli-cmd-page` tests: one asserting the lone favicon 404 becomes a note (no `Failed resources` block), and one asserting a real failed resource is still flagged alongside the favicon note. `npm run test:smoke`'s page suite passes (11/11).

## Scorecard from the motivating run

```
success: true (success)
cost(usd-equiv): 0.4561  turns: 35
tokens: 7251 (7146 in / 105 out)
tools: 34 total, 0 failed, retried: [Bash, Read, Glob]
tool counts: Bash×17, Read×13, Glob×3, Write×1
timing: whole 97.9s, in-LLM 93.9s, in-tools ~4.0s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)