### PR TITLE
fix: Make `gipity --help` print a complete, parseable subcommand list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,19 @@ program.configureHelp({
       lines.push('');
     }
 
+    // Flat, alphabetized "Commands:" section: the grouped view above is for
+    // humans, but agents grep for a standard greppable command list. Emit
+    // every top-level subcommand here so `--help | sed -n '/Commands:/,$p'`
+    // (and similar) returns the full set.
+    const allCmds = HELP_SECTIONS.flatMap(s => s.cmds)
+      .slice()
+      .sort((a, b) => a.name().localeCompare(b.name()));
+    lines.push(bold('Commands:'));
+    for (const c of allCmds) {
+      lines.push(`  ${padCmd(c.name())}  ${c.description()}`);
+    }
+    lines.push('');
+
     lines.push(dim(`Run "${cmd.name()} <command> --help" for details on a specific command.`));
     lines.push('');
     return lines.join('\n');


### PR DESCRIPTION
## Rationale

The agent ran five separate help invocations (`--help | grep env`, `| sed -n '/Commands:/,$p'`, bare `gipity`, `--help | tail -70`, `fn --help`) trying to find an env/secret command and to enumerate available commands. The grep/sed for a `Commands:` section returned empty because the top-level help had no standard, greppable command list — it only exposed grouped sections (Common/Connect/Project/...) and a prose quick-start block. This wasted several Bash turns on pure discoverability.

This change adds a flat, alphabetized `Commands:` section to `gipity --help` (and bare `gipity`) that lists every top-level subcommand with its one-line description. The grouped, human-friendly view is preserved; the new section gives agents a standard, parseable list so `gipity --help | sed -n '/Commands:/,$p'` (and similar) returns the full command set.

## Scorecard from the motivating run

```
success: false (db)
cost(usd-equiv): 0.0000  turns: 69
tokens: 57019 (12277 in / 44742 out)
tools: 42 total, 1 failed, retried: [Bash, Read, Write, Edit]
tool counts: Bash×17, Read×9, Write×10, Edit×6
timing: whole 303.5s, in-LLM 0.0s, in-tools ~303.5s
```

## Verification

- `npm run test:smoke` cli-smoke help suite passes (grouped sections still in order; doctor/update still under Setup).
- The 7 unrelated pre-existing failures (workflow command tests + tag drift guard) also fail on a clean `origin/main` checkout and are not touched by this change.
- Manually confirmed `gipity --help | sed -n '/Commands:/,$p'` now emits the full alphabetized command list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)