### PR TITLE
fix: Make `gipity add` give a helpful error when extra args look like `key=value`

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -157,7 +157,32 @@ export const addCommand = new Command('add')
   .option('--description <desc>', 'App description for meta tags - templates only')
   .option('--force', 'Templates only: overwrite any colliding files')
   .option('--json', 'Output as JSON')
-  .action((name: string | undefined, opts) => run('Add', async () => {
+  // Take the excess args ourselves instead of letting Commander bail with a
+  // bare "too many arguments" dump - we want to recognize the common mistake
+  // of passing metadata as `title=...` positionals and point at the flag form.
+  .allowExcessArguments(true)
+  .action((name: string | undefined, opts, command) => run('Add', async () => {
+    // Agents often type metadata as `gipity add 2d-game title="..."` instead of
+    // `--title "..."`. Catch the `key=value` shape and emit a directive hint
+    // mapping the recognized keys to their flags, rather than the raw Commander
+    // "too many arguments" error that sends them off to read --help.
+    const extras: string[] = command.args.slice(1);
+    if (extras.length) {
+      const FLAG_FOR: Record<string, string> = { title: '--title', description: '--description' };
+      const kv = extras.filter(a => a.includes('='));
+      if (kv.length) {
+        const suggestion = kv.map(a => {
+          const eq = a.indexOf('=');
+          const key = a.slice(0, eq);
+          const val = a.slice(eq + 1);
+          return `${FLAG_FOR[key] ?? `--${key}`} "${val}"`;
+        }).join(' ');
+        console.error(`Pass metadata as flags: gipity add ${name} ${suggestion}`);
+      } else {
+        console.error(`error: too many arguments for 'add'. Expected 1 argument but got ${extras.length + 1}.`);
+      }
+      process.exit(1);
+    }
     if (!name) {
       printCatalog();
       return;


### PR DESCRIPTION
## Rationale

`gipity add 2d-game title="Gip Brick Breaker"` returned the raw Commander error `error: too many arguments for add. Expected 1 argument but got 2.` — it didn't tell the agent that `title` should be `--title`, so the agent burned a turn reading `--help`. Per the CLI-fallthrough/agent-experience principle, a wrong-shaped arg should either route to the agent or emit a directive hint, not a bare Commander dump.

## Change

`add` now takes excess positional args itself (`allowExcessArguments(true)`) and inspects them before Commander bails:

- If any extra arg looks like `key=value`, it prints a directive hint mapping the recognized keys (`title`, `description`) to their flags, e.g.:
  ```
  Pass metadata as flags: gipity add 2d-game --title "Gip Brick Breaker"
  ```
- Other excess args keep the prior `too many arguments` behavior, so nothing is silently accepted.

Scoped to `src/commands/add.ts`. Typecheck (`tsc`) and `cli-cmd-add` tests pass; manually verified both the `key=value` hint path and the non-`key=value` fallback.

## Scorecard from the run that motivated this

```
success: false (db)
cost(usd-equiv): 0.0000  turns: 32
tokens: 35092 (7576 in / 27516 out)
tools: 18 total, 1 failed, retried: [Bash, Read, Write]
tool counts: Bash×9, Read×6, Write×3
timing: whole 156.0s, in-LLM 0.0s, in-tools ~156.0s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)