### PR TITLE
fix: Make `gipity page inspect` error clearly on unknown flags and suggest `gipity page eval`

### DIFF
--- a/src/__tests__/cli-cmd-page.test.ts
+++ b/src/__tests__/cli-cmd-page.test.ts
@@ -158,6 +158,31 @@ test('gipity page eval surfaces a failed eval job', async () => {
   assert.match(r.stderr, /about:blank/);
 });
 
+// `page inspect` takes no JS expression — `page eval` is the separate verb.
+// Reaching for `--eval` or pasting an expression should error AND point there.
+test('gipity page inspect errors on --eval and suggests page eval', async () => {
+  mock.reset();
+  const r = await run(['page', 'inspect', 'https://example.com', '--eval', '(()=>1)()']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /unknown option '--eval'/);
+  assert.match(r.stderr, /gipity page eval https:\/\/example\.com "<expression>"\?/);
+});
+
+test('gipity page inspect suggests page eval when a JS expression is pasted as an extra arg', async () => {
+  mock.reset();
+  const r = await run(['page', 'inspect', 'https://example.com', 'document.title']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /too many arguments/);
+  assert.match(r.stderr, /gipity page eval https:\/\/example\.com "<expression>"\?/);
+});
+
+test('gipity page inspect does not suggest page eval for a non-expression extra arg', async () => {
+  mock.reset();
+  const r = await run(['page', 'inspect', 'https://example.com', 'extra-thing']);
+  assert.notEqual(r.status, 0);
+  assert.doesNotMatch(r.stderr, /gipity page eval/);
+});
+
 // ── screenshot default filename helpers (pure) ─────────────────────────────
 
 test('timestampSlug renders yyyy-mm-dd_hh-mm-ss, zero-padded, sortable', () => {

--- a/src/commands/page.ts
+++ b/src/commands/page.ts
@@ -1,8 +1,37 @@
 import { Command } from 'commander';
+import { error as clrError, muted } from '../colors.js';
 import { pageInspectCommand } from './page-inspect.js';
 import { pageScreenshotCommand } from './page-screenshot.js';
 import { pageEvalCommand } from './page-eval.js';
 import { pageTestCommand } from './page-test.js';
+
+// `page inspect | screenshot | test` each take a URL but no JS expression —
+// `page eval` is the separate verb for running JS in page context. An agent
+// reaching for `--eval` (or pasting an expression as an extra positional) gets
+// commander's default unknown-option / too-many-arguments error, which names
+// neither the right verb nor that eval is a sibling. Append a pointer so the
+// fix is one read away instead of a multi-call detour through --help.
+function suggestEvalVerb(cmd: Command): Command {
+  cmd.configureOutput({
+    writeErr: (str) => {
+      process.stderr.write(clrError(str));
+      const triedEvalFlag = /unknown option '--eval/.test(str);
+      // The page URL is a positional, so it never follows a flag — that lets us
+      // skip URL-valued global options like `--api-base <url>` when picking it.
+      const argv = process.argv;
+      const url = argv.find((a, i) => /^https?:\/\//.test(a) && !(argv[i - 1] ?? '').startsWith('-'));
+      const pastedExpression =
+        /too many arguments/.test(str) &&
+        process.argv.some((a) => a !== url && /=>|\(\)|document\.|window\.|return\s/.test(a));
+      if (triedEvalFlag || pastedExpression) {
+        process.stderr.write(
+          muted(`Did you mean: gipity page eval ${url ?? '<url>'} "<expression>"?\n`),
+        );
+      }
+    },
+  });
+  return cmd;
+}
 
 // Parent namespace grouping the page/browser diagnostics under one command:
 //   gipity page inspect | eval | screenshot | test
@@ -10,10 +39,10 @@ import { pageTestCommand } from './page-test.js';
 // top-level surface lean and makes the siblings discoverable via `page --help`.
 export const pageCommand = new Command('page')
   .description('Inspect, evaluate, screenshot, and multi-client test web pages (page inspect | eval | screenshot | test)')
-  .addCommand(pageInspectCommand)
+  .addCommand(suggestEvalVerb(pageInspectCommand))
   .addCommand(pageEvalCommand)
-  .addCommand(pageScreenshotCommand)
-  .addCommand(pageTestCommand);
+  .addCommand(suggestEvalVerb(pageScreenshotCommand))
+  .addCommand(suggestEvalVerb(pageTestCommand));
 
 // No subcommand → show help instead of commander's terse error.
 pageCommand.action(() => {


### PR DESCRIPTION
## Rationale

The agent ran `gipity page inspect <url> --eval "(() => {...})()"` and got back a confusing dump of options (`--wait-for <selector>`, `--wait-timeout`, `--json`, `--no-truncate`) instead of an error — it never said the flag was invalid or that eval is a separate subcommand. That misleading output forced two more recovery calls (`gipity page inspect --help | grep eval` → no output, then `gipity page --help`) before the agent found `gipity page eval`. An unknown-option error that names the right verb collapses that 3-turn detour to zero.

## Change

`page inspect | screenshot | test` each take a URL but no JS expression — `page eval` is the separate verb for running JS in page context. These subcommands already exit non-zero on an unknown flag or excess argument, but the bare commander message named neither the right verb nor that eval is a sibling. This appends a one-line pointer to those errors:

```
$ gipity page inspect https://example.com --eval "(()=>1)()"
error: unknown option '--eval'
Did you mean: gipity page eval https://example.com "<expression>"?

$ gipity page inspect https://example.com "document.title"
error: too many arguments for 'inspect'. Expected 1 argument but got 2.
Did you mean: gipity page eval https://example.com "<expression>"?
```

The hint fires when `--eval` is the unknown flag or when a JS-looking expression is pasted as an extra positional, substituting the real page URL when present (and skipping URL-valued global options like `--api-base`). It is suppressed for ordinary excess arguments. Each subcommand's `--help` already shows only its own options. Covered by three new tests in `cli-cmd-page.test.ts`; the page suite passes (16/16).

## Scorecard from the motivating run

```
success: true (db)
cost(usd-equiv): 0.0000  turns: 33
tokens: 21901 (7697 in / 14204 out)
tools: 17 total, 0 failed, retried: [Bash, Read, Write, Edit]
tool counts: Bash×8, Read×4, Write×2, Edit×3
timing: whole 119.2s, in-LLM 0.0s, in-tools ~119.2s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)