### PR TITLE
feat: Have `gipity sandbox run` tell the user how to retrieve output files locally

### DIFF
--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -113,6 +113,7 @@ GCC/Rust).
       if (res.data.outputFiles && res.data.outputFiles.length > 0) {
         console.log(`\nOutput files saved to project:`);
         for (const f of res.data.outputFiles) console.log(`  ${f}`);
+        console.log(dim(`\nThese live in the project, not your working directory yet - run \`gipity sync\` to pull them down.`));
       }
       if (res.data.exitCode !== 0) process.exit(res.data.exitCode);
     }


### PR DESCRIPTION
## Rationale

The run's footer was `Output files saved to project: reports/...`, which reads as if the files are immediately usable; the agent's next `ls reports/` failed. The CLI is the cheapest place to set expectations — the agent reads this message right before deciding how to verify. Appending a retrieval hint to the "saved to project" line heads off the failed local read.

This appends a dimmed hint after the output-files summary:

> These live in the project, not your working directory yet - run `gipity sync` to pull them down.

## Scorecard from the run that motivated this

```
success: true (db)
cost(usd-equiv): 0.0000  turns: 18
tokens: 22193 (10249 in / 11944 out)
tools: 8 total, 0 failed, retried: [Bash, Write]
tool counts: Bash×5, Write×2, Read×1
timing: whole 95.2s, in-LLM 0.0s, in-tools ~95.2s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)