### PR TITLE
fix: Disambiguate `gipity page eval` '(empty result)' from a real undefined/null/empty value

### DIFF
--- a/src/commands/page-eval.ts
+++ b/src/commands/page-eval.ts
@@ -76,7 +76,19 @@ export const pageEvalCommand = new Command('eval')
 
     console.log(`\n${brand('Eval')} ${bold(d.url || url)}`);
     console.log(`  ${muted('Expression:')} ${expr}`);
-    console.log(`\n${d.result || muted('(empty result)')}`);
+    // Disambiguate a real empty value from eval failure or truncated output:
+    // mark the exact value the expression resolved to, so the caller doesn't keep
+    // probing a variable that simply isn't there. A genuine `undefined` arrives as
+    // a missing field (JSON drops `undefined`), so the typed `string` can be
+    // undefined/null/'' at runtime — distinguish each instead of collapsing all
+    // three into '(empty result)'.
+    const r = d.result as string | null | undefined;
+    let body: string;
+    if (r === undefined) body = muted('→ undefined');
+    else if (r === null) body = muted('→ null');
+    else if (r === '') body = muted('→ "" (empty string)');
+    else body = r;
+    console.log(`\n${body}`);
     if (d.truncated) console.log(muted('\n(result truncated to fit context - narrow the expression for the full value)'));
     console.log('');
   }));


### PR DESCRIPTION
## Rationale

The agent evaluated `JSON.stringify(window.__errs)` and got back `(empty result)` — because `window.__errs` was undefined, so `JSON.stringify(undefined)` is itself `undefined`. The agent couldn't tell whether the expression failed to run, returned undefined, or had its output truncated, so it kept building larger probe expressions (`{hasErrs: typeof window.__errs, n: ..., scripts: ...}`) chasing the same dead value. An explicit return-value marker would have told it immediately the variable simply didn't exist.

When the evaluated expression resolves to `undefined` / `null` / empty string, `gipity page eval` now prints an explicit marker (`→ undefined`, `→ null`, `→ "" (empty string)`) instead of the generic `(empty result)`, so the agent can distinguish "the expression ran and returned nothing meaningful" from "eval failed" or "output truncated." A genuine `undefined` arrives over the wire as a missing field (JSON drops `undefined`), so the typed `string` can be `undefined`/`null`/`''` at runtime — each is now disambiguated.

Implemented in `src/commands/page-eval.ts` (the `page eval` subcommand under the `page` namespace), where the `(empty result)` string is printed.

Distinct from PR #38, which documents eval's sync/await caveats — this is a tool-output clarity fix.

## Scorecard from the motivating run

```
success: true (db)
cost(usd-equiv): 0.0000  turns: 75
tokens: 0 (0 in / 0 out)
tools: 47 total, 0 failed, retried: [tool]
tool counts: tool×47
timing: whole 1.5s, in-LLM 0.0s, in-tools ~1.5s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)