### PR TITLE
fix: Make an unknown top-level `gipity` command (e.g. `browser`) suggest the nearest real command

### DIFF
--- a/src/__tests__/cli-smoke.test.ts
+++ b/src/__tests__/cli-smoke.test.ts
@@ -70,6 +70,16 @@ describe('cli-smoke: error behavior', () => {
     assert.match(out, /\bpage\b/);
   });
 
+  it('browser-automation guesses suggest `gipity page` directly', () => {
+    // `browser`/`screenshot`/`click` Levenshtein-match no real command, so an
+    // explicit alias hint collapses the guess straight onto the page surface.
+    for (const guess of ['browser', 'screenshot', 'click']) {
+      const r = runCli([guess]);
+      const out = r.stdout + r.stderr;
+      assert.match(out, /Did you mean `gipity page`\? \(inspect \| eval \| screenshot\)/, `no page hint for '${guess}'`);
+    }
+  });
+
   it('excess args print the error AND that command\'s help inline', () => {
     // Mirrors an agent guessing `gipity add <tmpl> title=...` (positional k=v).
     const r = runCli(['add', '2d-game', 'title=x']);

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,11 +205,34 @@ function fullCommandName(cmd: Command): string {
   for (let c: Command | null = cmd; c; c = c.parent) parts.unshift(c.name());
   return parts.join(' ');
 }
+
+// Browser-automation verbs an agent guesses as top-level commands
+// (`gipity browser screenshot`, `gipity click ...`) Levenshtein-match nothing,
+// so Commander's built-in suggestion stays silent. Point the whole family at
+// the real surface, `gipity page`, before falling back to the help catalog.
+const PAGE_HINT = 'Did you mean `gipity page`? (inspect | eval | screenshot)';
+const UNKNOWN_COMMAND_HINTS: Record<string, string> = {
+  browser: PAGE_HINT, screenshot: PAGE_HINT, screenshots: PAGE_HINT,
+  snap: PAGE_HINT, click: PAGE_HINT, type: PAGE_HINT, fill: PAGE_HINT,
+  navigate: PAGE_HINT, goto: PAGE_HINT, scrape: PAGE_HINT, dom: PAGE_HINT,
+  html: PAGE_HINT, eval: PAGE_HINT, inspect: PAGE_HINT,
+};
+function unknownCommandHint(errStr: string): string {
+  const m = errStr.match(/unknown command '([^']+)'/);
+  const hint = m && UNKNOWN_COMMAND_HINTS[m[1].toLowerCase()];
+  return hint ? `\n\n${hint}` : '';
+}
+
 function enableHelpAfterError(cmd: Command): void {
   cmd.showHelpAfterError(true);
+  // Generic nearest-command suggestion (`pag` → `page`) for close typos.
+  cmd.showSuggestionAfterError(true);
   cmd.configureOutput({
-    outputError: (str, write) =>
-      write(`${str.replace(/\n+$/, '')}\n\nShowing \`${fullCommandName(cmd)} --help\`:\n`),
+    outputError: (str, write) => {
+      // Intent-alias hint only at the top level, where command guesses land.
+      const hint = cmd === program ? unknownCommandHint(str) : '';
+      write(`${str.replace(/\n+$/, '')}${hint}\n\nShowing \`${fullCommandName(cmd)} --help\`:\n`);
+    },
   });
   for (const sub of cmd.commands) enableHelpAfterError(sub);
 }


### PR DESCRIPTION
## Rationale

The agent wanted to screenshot and click the Listen button and guessed `gipity browser --help`, `gipity browser screenshot`, and `gipity browser click --selector` — all `error: unknown command browser` — before discovering `gipity page screenshot` / `page eval`. A did-you-mean on unknown top-level commands collapses those three failed guesses into one.

This is distinct from CLI PR #4 (unknown *flags* on `page inspect`) and PR #2 (help completeness): this targets an unknown *top-level command* suggestion.

## Change

On an unknown top-level command, print a "did you mean" line before the help catalog:

- `program.showSuggestionAfterError(true)` covers close typos via Commander's built-in Levenshtein (`pag` → `page`).
- An intent-alias map points the browser-automation guess family (`browser`, `screenshot`, `click`, `type`, `fill`, `navigate`, `goto`, `scrape`, …) — none of which Levenshtein-match any real command — straight at `gipity page` (inspect | eval | screenshot).

```
$ gipity browser
error: unknown command 'browser'

Did you mean `gipity page`? (inspect | eval | screenshot)

Showing `gipity --help`:
```

Added a smoke test asserting the page hint for `browser`/`screenshot`/`click`. All 19 cli-smoke tests pass.

## Scorecard from the motivating run

```
success: false (db)
cost(usd-equiv): 0.0000  turns: 82
tokens: 378221 (15821 in / 362400 out)
tools: 60 total, 6 failed, retried: [Bash, Read, Write]
tool counts: Bash×26, Read×25, Glob×1, tool×1, Write×5, ToolSearch×1, Edit×1
timing: whole 220.6s, in-LLM 0.0s, in-tools ~220.6s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
