### PR TITLE
feat: Add `--wait-for <selector>` to `gipity page screenshot`/`eval` instead of a fixed 30s delay cap

### DIFF
--- a/src/commands/page-screenshot.ts
+++ b/src/commands/page-screenshot.ts
@@ -130,7 +130,9 @@ function appendOption(value: string, previous: string[] = []): string[] {
 export const pageScreenshotCommand = new Command('screenshot')
   .description('Screenshot a web page')
   .argument('<url>', 'URL to screenshot')
-  .option('--post-load-delay <ms>', 'Delay after DOMContentLoaded before capture, in ms', '1000')
+  .option('--post-load-delay <ms>', 'Delay after DOMContentLoaded before capture, in ms (server-capped at 30000)', '1000')
+  .option('--wait-for <selector>', 'Wait until this CSS selector appears before capturing (deterministic; for renders that exceed the --post-load-delay cap)')
+  .option('--wait-timeout <ms>', 'Max ms to wait for --wait-for before giving up', '120000')
   .option('--full', 'Capture the full scrollable page (default: viewport only)')
   .option('-o, --output <file>', 'Output path (single viewport only; default .gipity/screenshots/ss-<host>-<timestamp>.png)')
   .option('--device <names>', `Viewport preset(s): ${Object.keys(DEVICE_PRESETS).join(', ')} (comma-separated or repeat flag)`, appendOption, [] as string[])
@@ -145,6 +147,9 @@ export const pageScreenshotCommand = new Command('screenshot')
     if (postLoadDelayMs !== undefined && (!Number.isFinite(postLoadDelayMs) || postLoadDelayMs < 0)) {
       throw new Error('--post-load-delay must be a non-negative integer (ms)');
     }
+
+    const parsedTimeout = parseInt(String(opts.waitTimeout), 10);
+    const waitForTimeoutMs = Number.isFinite(parsedTimeout) && parsedTimeout >= 0 ? parsedTimeout : 120000;
 
     const deviceNames = splitCsv(opts.device as string[]);
     const viewportStrs = splitCsv(opts.viewport as string[]);
@@ -163,6 +168,8 @@ export const pageScreenshotCommand = new Command('screenshot')
     const body = {
       url,
       postLoadDelayMs,
+      waitForSelector: opts.waitFor || undefined,
+      waitForTimeoutMs: opts.waitFor ? waitForTimeoutMs : undefined,
       full: !!opts.full,
       reloadBetween: opts.reloadBetween !== false,
       ...(userSpecifiedViewports ? { viewports: customViewports } : {}),


### PR DESCRIPTION
## Rationale

`gipity page screenshot` only exposed `--post-load-delay`, which the server caps at 30000ms (`Page screenshot failed: Too big: expected number to be <=30000`). Pages whose render legitimately exceeds that cap can't be captured in their final state.

The motivating case: the app's first story page lands at ~32s (LLM 23s + image 6s + music 8.5s, measured in-transcript), just over the cap. Worse, the cap pressured changing the actual product — the agent swapped the story model (claude-sonnet-4-6 → gemini-2.5-flash → claude-haiku-4-5) partly to fit generation under the 30s screenshot window, letting a platform constraint distort the deliverable.

`--wait-for <selector>` captures once a DOM node appears, with a generous overall timeout, so the agent can verify the real rendered state regardless of generation time.

## Change

- Add `--wait-for <selector>` and `--wait-timeout <ms>` (default `120000`) to `page screenshot`, forwarded to the browser tool as `waitForSelector` / `waitForTimeoutMs` — the same flags `page inspect` and `page eval` already expose.
- `--post-load-delay` stays for the simple case; its help now notes the 30000ms server cap.
- `page eval` already supported `--wait-for`, so no change there.

Single-file change: `src/commands/page-screenshot.ts`. Smoke tests run; the change adds no new failures (8 pre-existing failures are present identically on `main`).

## Scorecard from the motivating run

```
success: false (db)
cost(usd-equiv): 0.0000  turns: 178
tokens: 279282 (15425 in / 263857 out)
tools: 81 total, 3 failed, retried: [Bash, Read, Write, Edit]
tool counts: Bash×39, Read×13, Write×17, Edit×11, ToolSearch×1
timing: whole 1806.8s, in-LLM 0.0s, in-tools ~1806.8s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
