### PR TITLE
fix: Make an unknown top-level `gipity <verb>` error and suggest the nearest command instead of printing the generic banner

### DIFF
--- a/src/__tests__/cli-smoke.test.ts
+++ b/src/__tests__/cli-smoke.test.ts
@@ -96,7 +96,7 @@ describe('cli-smoke: error behavior', () => {
 });
 
 describe('cli-smoke: subcommand --help wiring', () => {
-  for (const cmd of ['chat', 'deploy', 'db', 'fn', 'memory', 'scaffold', 'login', 'doctor', 'update']) {
+  for (const cmd of ['chat', 'deploy', 'db', 'fn', 'memory', 'add', 'login', 'doctor', 'update']) {
     it(`gipity ${cmd} --help exits 0`, () => {
       const r = runCli([cmd, '--help']);
       assert.equal(r.status, 0, `${cmd} --help failed: ${r.stderr}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,4 +229,31 @@ if (mappedCmd) {
   }
 }
 
+// ── Unknown top-level verb + `--help` → error, don't print the banner ─────
+// `gipity browser --help` otherwise short-circuits to the generic top-level
+// banner with exit 0 before Commander's unknown-command check runs, so the
+// verb being wrong is invisible (an agent can't tell `browser` from a real
+// command). When the leading operand isn't a known command, drop the help
+// flags so Commander's native unknown-command error fires instead — error +
+// "did you mean" suggestion + nonzero exit, identical to the no-`--help` case.
+{
+  const known = new Set(program.commands.flatMap(c => [c.name(), ...c.aliases()]));
+  const valueFlags = new Set(
+    program.options
+      .filter(o => o.required || o.optional)
+      .flatMap(o => [o.short, o.long].filter((f): f is string => !!f)),
+  );
+  const raw = process.argv.slice(2);
+  let i = 0;
+  while (i < raw.length && raw[i].startsWith('-')) {
+    if (valueFlags.has(raw[i])) i++; // skip the option's value token
+    i++;
+  }
+  const leading = raw[i];
+  const hasHelpFlag = raw.includes('--help') || raw.includes('-h');
+  if (leading && !known.has(leading) && hasHelpFlag) {
+    process.argv = process.argv.filter(a => a !== '--help' && a !== '-h');
+  }
+}
+
 program.parse(normalizeAliases(process.argv, program));


### PR DESCRIPTION
## What & why

`gipity browser --help` returned the full top-level help banner with exit 0 rather than an "unknown command" error. That silent fall-through is why an agent couldn't tell `browser` was wrong and had to probe a second command (`gipity page --help`); a "did you mean `page`?" style error would have collapsed the two help probes into zero.

Root cause: an unknown top-level verb followed by `--help` short-circuits to Commander's generic banner (exit 0) **before** the unknown-command check runs — so `program.on('command:*')` / `showSuggestionAfterError` never fire. The no-`--help` path already errors correctly with a suggestion (`enableHelpAfterError` + Commander's built-in suggestions).

## Change

In `src/index.ts`, before `program.parse`: detect the leading operand (skipping global value-options like `--api-base <url>`). When it isn't a known command and `--help`/`-h` is present, drop the help flags so Commander's native unknown-command path fires — `error: unknown command '<name>'` + `(Did you mean <x>?)` + nonzero exit, identical to the no-`--help` case.

Distinct from CLI PRs #2 (`--help` completeness) and #4 (unknown-flag on `page inspect`): this is about an unrecognized **top-level subcommand**.

### Before / after
```
$ gipity browser --help        # before: full banner, exit 0
$ gipity browser --help        # after:
error: unknown command 'browser'
Showing `gipity --help`: ...   exit 1

$ gipity pag --help            # after:
error: unknown command 'pag'
(Did you mean page?)           exit 1
```
Unaffected: `gipity --help` (top-level banner, exit 0), `gipity page --help` (page help, exit 0), `gipity browser` (already errored).

Also updates the cli-smoke `--help` wiring test, which listed `scaffold` — not a real command (replaced by `add`) — and passed only because of the banner fall-through this PR removes.

## Scorecard from the motivating run
```
success: true (db)
cost(usd-equiv): 0.0000  turns: 36
tokens: 28120 (8617 in / 19503 out)
tools: 18 total, 0 failed, retried: [Bash, Read, Write]
tool counts: Bash×9, Read×6, Write×3
timing: whole 140.5s, in-LLM 0.0s, in-tools ~140.5s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
