### PR TITLE
fix: Have `gipity generate speech|image|video` print the hosted public URL by default

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -73,6 +73,7 @@ Examples:
         const sizeKb = Math.round(result.size_bytes / 1024);
         console.log(`${muted(`Generated with ${result.provider}/${result.model} (${sizeKb}KB)`)}`);
         console.log(success(`Saved to ${savedPath}`));
+        console.log(info(`Hosted: ${result.url}`));
       }
     } catch (err: any) {
       console.error(clrError(`Image generation failed: ${err.message}`));
@@ -127,6 +128,7 @@ Examples:
         const sizeKb = Math.round(result.size_bytes / 1024);
         console.log(`${muted(`Generated with ${result.provider}/${result.model} (${sizeKb}KB)`)}`);
         console.log(success(`Saved to ${savedPath}`));
+        console.log(info(`Hosted: ${result.url}`));
       }
     } catch (err: any) {
       console.error(clrError(`Video generation failed: ${err.message}`));
@@ -185,6 +187,7 @@ Examples:
         const sizeKb = Math.round(result.size_bytes / 1024);
         console.log(`${muted(`Generated with ${result.provider} (${sizeKb}KB)`)}`);
         console.log(success(`Saved to ${savedPath}`));
+        console.log(info(`Hosted: ${result.url}`));
       }
     } catch (err: any) {
       console.error(clrError(`Speech generation failed: ${err.message}`));


### PR DESCRIPTION
## Rationale

The agent generated a TTS test note; the default output only said `Generated with elevenlabs (340KB) / Saved to speech.mp3`, so the agent ("It saved locally but I need a public URL the job can fetch") had to re-run the command with `--json` to discover the already-hosted `https://media.gipity.ai/_api-media/med_c9b8djxd.mp3` URL. The asset is already uploaded — the URL was just hidden from the human-readable output.

This change prints the hosted public URL alongside the local save path in the default (non-JSON) output for `generate speech`, `generate image`, and `generate video` (e.g. `Hosted: https://media.gipity.ai/_api-media/...`). This is the value a developer needs to feed the asset into a job or function, with no extra `--json` round-trip.

## Scorecard from the run that motivated this

```
success: false (db)
cost(usd-equiv): 0.0000  turns: 191
tokens: 3064 (4 in / 3060 out)
tools: 96 total, 3 failed, retried: [tool]
tool counts: tool×96
timing: whole 18.0s, in-LLM 0.0s, in-tools ~18.0s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)