### PR TITLE
fix: Make `gipity deploy` warn when deployable web files sit at the project root outside src/

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,6 +1,8 @@
 import { Command } from 'commander';
+import { existsSync, readdirSync, statSync } from 'fs';
+import { join, resolve } from 'path';
 import { post } from '../api.js';
-import { requireConfig } from '../config.js';
+import { requireConfig, getProjectRoot } from '../config.js';
 import { formatSize } from '../utils.js';
 import { success, error as clrError, warning, muted, bold, brand } from '../colors.js';
 import { run, syncBeforeAction } from '../helpers/index.js';
@@ -12,6 +14,40 @@ function statusIcon(status: string): string {
   if (status === 'failed') return clrError('✗');
   if (status === 'warning') return warning('⚠');
   return muted('→');
+}
+
+// ── Stranded web-file warning ──────────────────────────────────────────
+// Deploys ship a single source root (src/ by default). Web files written to
+// the project root instead are silently dropped by the server, which has
+// burned agents into shipping the untouched template and discovering it only
+// on page inspect. Warn (non-fatal) so the mistake surfaces at deploy time.
+function warnStrandedWebFiles(deployRoot: string): void {
+  const projectRoot = getProjectRoot();
+  if (!projectRoot) return;
+  const rel = deployRoot.replace(/^\.\//, '').replace(/\/+$/, '');
+  // When deploying from the project root itself, nothing is stranded.
+  if (rel === '' || rel === '.') return;
+
+  const deployRootAbs = resolve(projectRoot, rel);
+  const stranded: string[] = [];
+  try {
+    for (const entry of readdirSync(projectRoot)) {
+      const abs = join(projectRoot, entry);
+      if (abs === deployRootAbs) continue; // skip the deploy root itself
+      if (entry === 'index.html' || entry.endsWith('.html')) {
+        stranded.push(entry);
+      } else if ((entry === 'css' || entry === 'js') && existsSync(abs) && statSync(abs).isDirectory()) {
+        stranded.push(entry + '/');
+      }
+    }
+  } catch {
+    return; // best-effort; never block the deploy
+  }
+  if (stranded.length === 0) return;
+  console.log(`  ${warning(
+    `Note: ${stranded.join(', ')} found at project root but the deploy root is ${rel}/ — ` +
+    `these files were NOT deployed. Move them under ${rel}/.`,
+  )}`);
 }
 
 // ── Main Deploy Command ────────────────────────────────────────────────
@@ -88,6 +124,9 @@ export const deployCommand = new Command('deploy')
       if (d.warning) {
         console.log(`  ${warning(d.warning)}`);
       }
+
+      // Flag deployable web files stranded at the project root, outside src/.
+      warnStrandedWebFiles(opts.sourceDir || 'src');
 
       // Show example curl commands for public endpoints
       if (d.examples && d.examples.length > 0) {


### PR DESCRIPTION
## Rationale

The agent wrote `index.html`, `css/styles.css` and `js/main.js` to the project **root**, then `gipity deploy dev` reported `✓ files: 8 files deployed` and the page still showed the placeholder title `gr-2026-05-31-...` — it had silently shipped the untouched `src/` template and ignored the root files entirely. The agent only discovered this after a page inspect (*"the deploy shipped the default template, not my word counter"*) and spent ~6 turns (find/cat/rm) cleaning up.

This change makes `gipity deploy` scan the project root after resolving the deploy root (`src/` by default). If common web files (`index.html`, `*.html`, `css/`, `js/`) exist at the root but **outside** the deploy root, it prints a non-fatal warning naming `src/` as the deploy root and telling the user those files were not deployed. The deploy is never blocked — the warning is purely advisory.

Example:

```
Note: index.html, css/, js/ found at project root but the deploy root is src/ — these files were NOT deployed. Move them under src/.
```

## Scorecard from the motivating run

```
success: false (db)
cost(usd-equiv): 0.0000  turns: 48
tokens: 467474 (40568 in / 426906 out)
tools: 30 total, 10 failed, retried: [Bash, Read, Write, Edit]
tool counts: Bash×14, Read×7, Write×6, tool×1, Edit×2
timing: whole 169.1s, in-LLM 0.0s, in-tools ~169.1s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
