### PR TITLE
feat: Add a way to screenshot/inspect page state after running setup JS (stateful browser session)

### DIFF
--- a/src/commands/page-screenshot.ts
+++ b/src/commands/page-screenshot.ts
@@ -137,8 +137,10 @@ export const pageScreenshotCommand = new Command('screenshot')
   .option('--viewport <dims>', 'Raw viewport(s): WxH or WxH@dpr (comma-separated or repeat flag)', appendOption, [] as string[])
   .option('--no-reload-between', 'Skip reload between viewports (faster, lower fidelity - only safe for static pages)')
   .option('--fake-media', 'Grant a synthetic microphone + camera and auto-accept the getUserMedia prompt, so voice/camera apps render headlessly (audio is a built-in tone, not real speech)')
+  .option('--eval <js>', 'Run this JS in the page and await it before capturing - builds state in the same session (e.g. draw shapes via a test hook) so the screenshot shows the result of an interaction, not a fresh load')
   .option('--json', 'Output JSON metadata instead of a friendly summary')
   .addOption(new Option('--wait <ms>', 'Alias for --post-load-delay').hideHelp())
+  .addOption(new Option('--setup <js>', 'Alias for --eval').hideHelp())
   .action((url: string, opts) => run('Page screenshot', async () => {
     const delayRaw = opts.postLoadDelay ?? opts.wait;
     const postLoadDelayMs = delayRaw !== undefined ? parseInt(String(delayRaw), 10) : undefined;
@@ -157,6 +159,15 @@ export const pageScreenshotCommand = new Command('screenshot')
       throw new Error('--output can only be used with a single viewport');
     }
 
+    // --eval/--setup: JS to run in the page before capture, so the shot shows
+    // the result of an interaction (state built in the same session).
+    const setupJs: string | undefined = opts.eval ?? opts.setup;
+    // A reload between viewports throws away whatever the setup JS built, so the
+    // multi-viewport reload path can't carry that state forward.
+    if (setupJs && customViewports.length > 1 && opts.reloadBetween !== false) {
+      throw new Error('--eval is incompatible with multiple viewports unless --no-reload-between is set (reload wipes the state the JS built); use one viewport or pass --no-reload-between');
+    }
+
     // Server defaults to 1280×720 when viewports is omitted - don't send it in
     // the no-flag case so the filename stays unsuffixed (no viewport segment).
     const userSpecifiedViewports = customViewports.length > 0;
@@ -167,6 +178,7 @@ export const pageScreenshotCommand = new Command('screenshot')
       reloadBetween: opts.reloadBetween !== false,
       ...(userSpecifiedViewports ? { viewports: customViewports } : {}),
       ...(opts.fakeMedia ? { fakeMedia: true } : {}),
+      ...(setupJs ? { setupJs } : {}),
     };
 
     const entries = await postForTarEntries('/tools/browser/screenshot', body);


### PR DESCRIPTION
## What

Add `--eval <js>` (alias `--setup <js>`) to `gipity page screenshot`. The JS runs in the page and is awaited **before** capture, so the screenshot reflects state built in the same browser session (e.g. drawing shapes via a test hook) instead of a fresh page load.

The flag is forwarded to the server as `setupJs` in the `/tools/browser/screenshot` request body, mirroring how `fakeMedia` and `reloadBetween` are passed. A guard rejects `--eval` combined with multiple viewports unless `--no-reload-between` is set, since reloading between viewports discards whatever the setup JS built.

## Rationale

The motivating run: an agent wanted to draw a scene and screenshot it, but found "The screenshot loads a fresh page, so my eval-drawn scene won't appear." It explicitly ran ToolSearch for an "interactive browser open eval screenshot" tool, found none, and worked around it by exporting the app's SVG via eval and rasterizing it in the sandbox — which itself hit a missing-delegate error. Both `page eval` and `page screenshot` load a fresh page, so there was no way to capture the visual result of an interaction. This flag closes that gap with a single stateful session.

## Scorecard from the motivating run

```
success: false (db)
cost(usd-equiv): 0.0000  turns: 278
tokens: 496382 (23698 in / 472684 out)
tools: 131 total, 2 failed, retried: [Bash, Write, Edit, ToolSearch, TaskCreate, Read, TaskUpdate]
tool counts: Bash×42, Write×41, Edit×31, ToolSearch×2, TaskCreate×7, tool×1, Read×5, TaskUpdate×2
timing: whole 2357.7s, in-LLM 0.0s, in-tools ~2357.7s
```

## Testing

- `npm run build` (tsc) clean
- `node --test dist/__tests__/cli-cmd-page.test.js` — 13/13 pass
- `node --test dist/__tests__/cli-smoke.test.js` — 18/18 pass
- Verified `gipity page screenshot --help` shows the new `--eval` flag (`--setup` hidden alias)

🤖 Generated with [Claude Code](https://claude.com/claude-code)