### PR TITLE
fix: Make `gipity generate image --out` create the parent directory instead of ENOENT

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,8 +1,8 @@
 import { Command } from 'commander';
 import { post } from '../api.js';
 import { resolveProjectContext } from '../config.js';
-import { writeFileSync } from 'fs';
-import { resolve as resolvePath } from 'path';
+import { writeFileSync, mkdirSync } from 'fs';
+import { resolve as resolvePath, dirname } from 'path';
 import { error as clrError, success, muted, info } from '../colors.js';
 import { IMAGE_MODELS_DOC, IMAGE_GEMINI_ASPECT_RATIOS, IMAGE_GEMINI_SIZES, VIDEO_MODELS_DOC, TTS_PROVIDER_DESCRIPTIONS, GEMINI_TTS_VOICES_DOC } from '../provider-docs.js';
 
@@ -20,6 +20,7 @@ async function downloadFile(url: string, filename: string): Promise<string> {
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Download failed: ${res.status}`);
   const buffer = Buffer.from(await res.arrayBuffer());
+  mkdirSync(dirname(resolvePath(filename)), { recursive: true });
   writeFileSync(filename, buffer);
   return resolvePath(filename);
 }


### PR DESCRIPTION
## Rationale

The agent ran `gipity generate image "..." --out src/test/streetscene.jpg` and got `Image generation failed: ENOENT: no such file or directory, open 'src/test/streetscene.jpg'` — the image was generated but couldn't be written because `src/test/` didn't exist. The agent had to retry with a manual `mkdir -p src/test &&` prefix.

A generate command that already produced the asset should `mkdir -p` the `--out` parent rather than throwing away the result on a missing dir. The fix lives in the shared `downloadFile` helper, so it applies to all `gipity generate <image|video|speech>` subcommands that accept `--out`.

## Change

Before writing the generated asset, `mkdirSync(dirname(resolvePath(filename)), { recursive: true })`.

## Scorecard from the run that motivated this

```
success: true (db)
cost(usd-equiv): 0.0000  turns: 75
tokens: 76500 (11397 in / 65103 out)
tools: 38 total, 0 failed, retried: [Bash, Read, Edit]
tool counts: Bash×25, Read×7, Edit×5, Write×1
timing: whole 622.7s, in-LLM 0.0s, in-tools ~622.7s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)