### PR TITLE
fix: Honor (or clearly cap) `gipity sandbox run --timeout` instead of a hidden gateway kill

### DIFF
--- a/src/__tests__/cli-cmd-sandbox.test.ts
+++ b/src/__tests__/cli-cmd-sandbox.test.ts
@@ -38,6 +38,28 @@ test('gipity sandbox run with --language python posts language=python', async ()
   assert.match(r.stdout, /42/);
 });
 
+test('gipity sandbox run refuses --timeout above the wall-clock cap before submitting', async () => {
+  mock.reset();
+  let hit = false;
+  mock.on('POST /projects/p_TestProj/sandbox/execute', () => {
+    hit = true;
+    return { body: { data: { exitCode: 0, stdout: '', stderr: '', durationMs: 0, timedOut: false } } };
+  });
+  const r = await fresh(['sandbox', 'run', '--timeout', '120', 'console.log(1)']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /capped at 10s/);
+  assert.equal(hit, false, 'must not POST to the server when over the cap');
+});
+
+test('gipity sandbox run surfaces the real wall-clock limit on a gateway 504', async () => {
+  mock.reset();
+  mock.on('POST /projects/p_TestProj/sandbox/execute', { status: 504, raw: 'Gateway Time-out', contentType: 'text/html' });
+  const r = await fresh(['sandbox', 'run', 'console.log(1)']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /exceeded sandbox wall-clock limit of 10s/);
+  assert.doesNotMatch(r.stderr, /Gateway Time-out/);
+});
+
 test('gipity sandbox run lists output files when present', async () => {
   mock.reset();
   mock.on('POST /projects/p_TestProj/sandbox/execute', { body: { data: {

--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -1,9 +1,15 @@
 import { Command } from 'commander';
 import { dirname, relative } from 'path';
-import { post } from '../api.js';
+import { post, ApiError } from '../api.js';
 import { resolveProjectContext, getConfigPath } from '../config.js';
 import { error as clrError, dim } from '../colors.js';
 import { run } from '../helpers/index.js';
+
+/** Real wall-clock ceiling enforced by the API gateway. Requests that run
+ *  longer are killed gateway-side with a 504, regardless of the requested
+ *  --timeout. Cap/validate against this so we never advertise a number the
+ *  platform won't honor. */
+const MAX_TIMEOUT_SECONDS = 10;
 
 const LANG_MAP: Record<string, string> = {
   js: 'javascript',
@@ -32,7 +38,7 @@ sandboxCommand
   .command('run <code>')
   .description('Run code')
   .option('--language <language>', 'Language: js, py, or bash', 'js')
-  .option('--timeout <seconds>', 'Execution timeout in seconds', '30')
+  .option('--timeout <seconds>', `Execution timeout in seconds (max ${MAX_TIMEOUT_SECONDS}, the gateway wall-clock cap)`, String(MAX_TIMEOUT_SECONDS))
   .option(
     '--input <path>',
     'Narrow to specific project files instead of auto-mirroring the whole tree (repeatable). Use this only for >1 GB projects or when you want surgical control.',
@@ -80,9 +86,16 @@ GCC/Rust).
     }
 
     const timeout = parseInt(opts.timeout, 10);
+    if (!isNaN(timeout) && timeout > MAX_TIMEOUT_SECONDS) {
+      console.error(clrError(
+        `sandbox runs are capped at ${MAX_TIMEOUT_SECONDS}s of wall-clock; ` +
+        `--timeout ${timeout} cannot be honored — chunk the work`,
+      ));
+      process.exit(1);
+    }
     const cwd = resolveRelativeCwd();
 
-    const res = await post<{
+    type ExecResponse = {
       data: {
         exitCode: number;
         stdout: string;
@@ -93,13 +106,25 @@ GCC/Rust).
         mirroredCount?: number;
         autoMirrorSkipped?: { reason: string; totalBytes: number };
       };
-    }>(`/projects/${config.projectGuid}/sandbox/execute`, {
-      code,
-      language,
-      timeout: isNaN(timeout) ? 30 : timeout,
-      input_files: opts.input,
-      cwd,
-    });
+    };
+
+    let res: ExecResponse;
+    try {
+      res = await post<ExecResponse>(`/projects/${config.projectGuid}/sandbox/execute`, {
+        code,
+        language,
+        timeout: isNaN(timeout) ? MAX_TIMEOUT_SECONDS : timeout,
+        input_files: opts.input,
+        cwd,
+      });
+    } catch (err) {
+      // The gateway kills over-long runs with a 504; surface the real limit
+      // instead of the generic "Gateway Time-out".
+      if (err instanceof ApiError && err.statusCode === 504) {
+        throw new Error(`exceeded sandbox wall-clock limit of ${MAX_TIMEOUT_SECONDS}s`);
+      }
+      throw err;
+    }
 
     if (opts.json) {
       console.log(JSON.stringify(res.data));


### PR DESCRIPTION
## Rationale

`gipity sandbox run --timeout` advertised values up to 120s, but the API gateway kills any run far earlier with a generic `Sandbox failed: Gateway Time-out`. In the motivating run the agent set `--timeout` to 120, then 50, 25, 18, 14 — **every** run still died in ~10-30s, and it had to reverse-engineer the real ceiling ("the harness gateway kills the run at ~10s wall-clock"). The flag kept promising a number the platform never respected.

This change makes the CLI honest about the real wall-clock ceiling instead of relying on a hidden gateway kill:

- Adds `MAX_TIMEOUT_SECONDS` (the gateway wall-clock cap) and makes it the default for `--timeout`.
- Validates `--timeout` **before** submitting: if it exceeds the cap, errors out with `sandbox runs are capped at 10s of wall-clock; --timeout <requested> cannot be honored — chunk the work`.
- On a gateway `504`, surfaces `exceeded sandbox wall-clock limit of 10s` instead of the opaque `Gateway Time-out`.
- Tests cover both the up-front refusal (no POST is made) and the 504 remap.

Scoped to `src/commands/sandbox.ts` plus its test. The full smoke suite's other failures (workflow/text/tag-drift suites) are pre-existing on `origin/main` and untouched by this change; the 5 sandbox tests pass.

## Scorecard from the motivating run

```
success: false (db)
cost(usd-equiv): 0.0000  turns: 168
tokens: 355178 (17063 in / 338115 out)
tools: 77 total, 6 failed, retried: [Bash, Write, Read, Edit, ScheduleWakeup]
tool counts: Bash×38, Write×16, Read×6, Edit×15, ScheduleWakeup×2
timing: whole 2340.8s, in-LLM 0.0s, in-tools ~2340.8s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
