### PR TITLE
fix: Make 'Sandbox queue timeout - all containers busy' actionable and note background runs hold a container

### DIFF
--- a/src/__tests__/cli-cmd-sandbox.test.ts
+++ b/src/__tests__/cli-cmd-sandbox.test.ts
@@ -38,6 +38,19 @@ test('gipity sandbox run with --language python posts language=python', async ()
   assert.match(r.stdout, /42/);
 });
 
+test('gipity sandbox run rewrites the all-containers-busy error to be actionable', async () => {
+  mock.reset();
+  mock.on('POST /projects/p_TestProj/sandbox/execute', { status: 503, body: {
+    error: { code: 'SANDBOX_BUSY', message: 'Sandbox queue timeout - all containers busy' },
+    data: { run_id: 'run_abc123' },
+  } });
+  const r = await fresh(['sandbox', 'run', 'console.log(1)']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /all sandbox containers are busy/);
+  assert.match(r.stderr, /background job run_abc123/);
+  assert.match(r.stderr, /wait for it to finish or stop it before retrying/);
+});
+
 test('gipity sandbox run lists output files when present', async () => {
   mock.reset();
   mock.on('POST /projects/p_TestProj/sandbox/execute', { body: { data: {

--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { dirname, relative } from 'path';
-import { post } from '../api.js';
+import { post, ApiError } from '../api.js';
 import { resolveProjectContext, getConfigPath } from '../config.js';
 import { error as clrError, dim } from '../colors.js';
 import { run } from '../helpers/index.js';
@@ -23,6 +23,29 @@ function resolveRelativeCwd(): string | undefined {
   const rel = relative(projectRoot, process.cwd());
   if (!rel || rel.startsWith('..')) return undefined;
   return rel.split(/[\\/]/).filter(Boolean).join('/');
+}
+
+/** The server returns a terse "Sandbox queue timeout - all containers busy" when
+ *  every sandbox container is in use. That tells the agent nothing about cause or
+ *  remedy — and in practice the occupant is often the caller's own still-running
+ *  `--background` sandbox job holding the only container. Rewrite the busy error to
+ *  name the cause and the fix, surfacing the in-flight run id when the server sends
+ *  one so the agent can correlate it with its own background task. */
+function enrichSandboxError(err: unknown): unknown {
+  if (!(err instanceof ApiError)) return err;
+  if (!/all containers busy|queue timeout/i.test(err.message)) return err;
+  const runId = typeof err.data?.run_id === 'string' ? err.data.run_id
+    : typeof err.data?.runId === 'string' ? err.data.runId
+    : undefined;
+  const culprit = runId
+    ? `a previous run (possibly your own background job ${runId})`
+    : 'a previous run (possibly your own background job)';
+  return new ApiError(
+    err.statusCode,
+    err.code,
+    `all sandbox containers are busy — ${culprit} is still executing; wait for it to finish or stop it before retrying`,
+    err.data,
+  );
 }
 
 export const sandboxCommand = new Command('sandbox')
@@ -99,7 +122,7 @@ GCC/Rust).
       timeout: isNaN(timeout) ? 30 : timeout,
       input_files: opts.input,
       cwd,
-    });
+    }).catch((err) => { throw enrichSandboxError(err); });
 
     if (opts.json) {
       console.log(JSON.stringify(res.data));


### PR DESCRIPTION
## Rationale

After kicking off a background sim, the agent's next `gipity sandbox run` calls failed three times in a row with `Sandbox queue timeout - all containers busy`, then it had to blindly `sleep 8` / `sleep 20` and retry. The bare message gives no cause or remedy, and nothing told the agent that its own still-running background sandbox job was the thing occupying the only container.

This rewrites the busy error in the CLI (`src/commands/sandbox.ts`) to name the cause and the fix:

> all sandbox containers are busy — a previous run (possibly your own background job `<id>`) is still executing; wait for it to finish or stop it before retrying

When the server reports an in-flight run id (`data.run_id` / `data.runId`), it is surfaced inline so the agent can correlate it with its own background task. Detection matches the server's existing `all containers busy` / `queue timeout` message, so no server change is required; non-matching `ApiError`s pass through untouched. A unit test covers the rewrite.

## Scorecard from the run that motivated this

```
success: false (db)
cost(usd-equiv): 0.0000  turns: 168
tokens: 355178 (17063 in / 338115 out)
tools: 77 total, 6 failed, retried: [Bash, Write, Read, Edit, ScheduleWakeup]
tool counts: Bash×38, Write×16, Read×6, Edit×15, ScheduleWakeup×2
timing: whole 2340.8s, in-LLM 0.0s, in-tools ~2340.8s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)