### PR TITLE
fix: Make `gipity sandbox run` wait/back off when all containers are busy instead of instant-failing

### DIFF
--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { dirname, relative } from 'path';
-import { post } from '../api.js';
+import { post, ApiError } from '../api.js';
 import { resolveProjectContext, getConfigPath } from '../config.js';
 import { error as clrError, dim } from '../colors.js';
 import { run } from '../helpers/index.js';
@@ -13,6 +13,55 @@ const LANG_MAP: Record<string, string> = {
   bash: 'bash',
   sh: 'bash',
 };
+
+type SandboxExecResult = {
+  data: {
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+    durationMs: number;
+    timedOut: boolean;
+    outputFiles?: string[];
+    mirroredCount?: number;
+    autoMirrorSkipped?: { reason: string; totalBytes: number };
+  };
+};
+
+/** Server emits this when every container is occupied. Transient + retryable,
+ *  not a real execution failure. */
+const BUSY_RE = /all containers busy/i;
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+function isAllContainersBusy(res: SandboxExecResult): boolean {
+  return res.data.exitCode !== 0 && BUSY_RE.test(res.data.stderr ?? '');
+}
+
+/** POST the sandbox execute request, retrying with exponential backoff (1s,
+ *  doubling, capped at 8s) while all containers are busy, up to `budgetMs`.
+ *  Returns null if still busy at the deadline. Non-busy errors propagate. */
+async function executeWithBackoff(
+  path: string, body: unknown, budgetMs: number, quiet: boolean,
+): Promise<SandboxExecResult | null> {
+  const deadline = Date.now() + budgetMs;
+  let backoffMs = 1000;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      const res = await post<SandboxExecResult>(path, body);
+      if (!isAllContainersBusy(res)) return res;
+    } catch (err) {
+      if (!(err instanceof ApiError && BUSY_RE.test(err.message))) throw err;
+    }
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return null;
+    const delay = Math.min(backoffMs, remaining);
+    if (!quiet) {
+      console.error(dim(`All sandbox containers busy; retrying in ${Math.ceil(delay / 1000)}s (attempt ${attempt})...`));
+    }
+    await sleep(delay);
+    backoffMs = Math.min(backoffMs * 2, 8000);
+  }
+}
 
 /** Project-relative path from the process cwd, or undefined when there's
  *  no local config (one-off mode) or the cwd is at/above the project root. */
@@ -33,6 +82,7 @@ sandboxCommand
   .description('Run code')
   .option('--language <language>', 'Language: js, py, or bash', 'js')
   .option('--timeout <seconds>', 'Execution timeout in seconds', '30')
+  .option('--wait <seconds>', 'Max seconds to wait/back off for a free container when all are busy', '60')
   .option(
     '--input <path>',
     'Narrow to specific project files instead of auto-mirroring the whole tree (repeatable). Use this only for >1 GB projects or when you want surgical control.',
@@ -82,24 +132,29 @@ GCC/Rust).
     const timeout = parseInt(opts.timeout, 10);
     const cwd = resolveRelativeCwd();
 
-    const res = await post<{
-      data: {
-        exitCode: number;
-        stdout: string;
-        stderr: string;
-        durationMs: number;
-        timedOut: boolean;
-        outputFiles?: string[];
-        mirroredCount?: number;
-        autoMirrorSkipped?: { reason: string; totalBytes: number };
-      };
-    }>(`/projects/${config.projectGuid}/sandbox/execute`, {
-      code,
-      language,
-      timeout: isNaN(timeout) ? 30 : timeout,
-      input_files: opts.input,
-      cwd,
-    });
+    const waitSeconds = parseInt(opts.wait, 10);
+    const waitBudgetMs = (isNaN(waitSeconds) ? 60 : Math.max(0, waitSeconds)) * 1000;
+
+    const res = await executeWithBackoff(
+      `/projects/${config.projectGuid}/sandbox/execute`,
+      {
+        code,
+        language,
+        timeout: isNaN(timeout) ? 30 : timeout,
+        input_files: opts.input,
+        cwd,
+      },
+      waitBudgetMs,
+      !!opts.json,
+    );
+
+    if (!res) {
+      console.error(clrError(
+        'All sandbox containers are busy. This is transient - re-run the same command shortly, '
+        + 'or pass --wait <seconds> to wait longer for a free container.',
+      ));
+      process.exit(1);
+    }
 
     if (opts.json) {
       console.log(JSON.stringify(res.data));


### PR DESCRIPTION
## Rationale

The agent's first real verification step — `gipity sandbox run` to render a deterministic text image — returned instantly (`durationMs:0`) with `{"stderr":"Sandbox queue timeout - all containers busy"}`. It retried 5+ times across foreground and a backgrounded `for i in 1 2 3` loop, all instant-failing, then gave up on the sandbox entirely and worked around it by curling placehold.co.

The error fires immediately rather than queueing, so the agent has no signal that the right move is to wait, and no built-in wait to lean on — it just hammers the same failing call.

## Change

`src/commands/sandbox.ts`:
- When the backend reports `all containers busy`, no longer return immediately. The execute request now retries with bounded exponential backoff (1s, doubling, capped at 8s) up to a default ~60s budget before failing.
- Add a `--wait <seconds>` flag to extend (or shorten) that budget.
- Non-busy errors propagate unchanged; successful runs are unaffected.
- If still busy at the deadline, emit a message stating the condition is transient and that the call can be retried (or `--wait` extended), instead of the bare `Sandbox queue timeout - all containers busy`.

Underlying container-pool capacity is an infra concern to escalate separately; this PR fixes the CLI's instant-fail-with-no-guidance behavior that cost the run the most turns.

## Scorecard from the motivating run

```
success: false (db)
cost(usd-equiv): 0.0000  turns: 71
tokens: 61836 (14019 in / 47817 out)
tools: 34 total, 1 failed, retried: [Bash, Read, Write, Edit, ToolSearch]
tool counts: Bash×17, Read×6, Write×4, Edit×5, ToolSearch×2
timing: whole 586.1s, in-LLM 0.0s, in-tools ~586.1s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)