### PR TITLE
fix: Make '[Browser command timed out]' distinguish a worker outage from a slow page and suggest the curl fallback

### DIFF
--- a/src/commands/page-eval.ts
+++ b/src/commands/page-eval.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { post, get, ApiError } from '../api.js';
 import { brand, bold, muted } from '../colors.js';
-import { run } from '../helpers/index.js';
+import { runBrowser } from '../helpers/index.js';
 
 interface EvalResult {
   url: string;
@@ -56,7 +56,7 @@ export const pageEvalCommand = new Command('eval')
   .option('--wait-for <selector>', 'Wait until this CSS selector appears before evaluating (deterministic; replaces --wait)')
   .option('--wait-timeout <ms>', 'Max ms to wait for --wait-for before giving up', '5000')
   .option('--json', 'Output as JSON')
-  .action((url: string, expr: string, opts) => run('Page eval', async () => {
+  .action((url: string, expr: string, opts) => runBrowser('Page eval', url, async () => {
     const parsedWait = parseInt(opts.wait, 10);
     const waitMs = Number.isFinite(parsedWait) && parsedWait >= 0 ? parsedWait : 500;
     const parsedTimeout = parseInt(opts.waitTimeout, 10);

--- a/src/commands/page-inspect.ts
+++ b/src/commands/page-inspect.ts
@@ -2,7 +2,7 @@ import { Command, Option } from 'commander';
 import { post } from '../api.js';
 import { formatSize } from '../utils.js';
 import { brand, bold, error as clrError, warning, muted, info } from '../colors.js';
-import { run } from '../helpers/index.js';
+import { runBrowser } from '../helpers/index.js';
 
 interface DebugBundle {
   url: string;
@@ -59,7 +59,7 @@ export const pageInspectCommand = new Command('inspect')
       console.error(`  gipity page screenshot ${url}${typeof opts.screenshot === 'string' ? ` -o ${opts.screenshot}` : ''}`);
       process.exit(1);
     }
-    return run('Page inspect', async () => {
+    return runBrowser('Page inspect', url, async () => {
     const parsedWait = parseInt(opts.wait, 10);
     const waitMs = Number.isFinite(parsedWait) && parsedWait >= 0 ? parsedWait : 500;
     const parsedTimeout = parseInt(opts.waitTimeout, 10);

--- a/src/commands/page-screenshot.ts
+++ b/src/commands/page-screenshot.ts
@@ -5,7 +5,7 @@ import { postForTarEntries } from '../api.js';
 import { getProjectRoot } from '../config.js';
 import { brand, bold, muted, success } from '../colors.js';
 import { formatSize } from '../utils.js';
-import { run } from '../helpers/index.js';
+import { runBrowser } from '../helpers/index.js';
 
 type Viewport = { width: number; height: number; deviceScaleFactor?: number };
 
@@ -139,7 +139,7 @@ export const pageScreenshotCommand = new Command('screenshot')
   .option('--fake-media', 'Grant a synthetic microphone + camera and auto-accept the getUserMedia prompt, so voice/camera apps render headlessly (audio is a built-in tone, not real speech)')
   .option('--json', 'Output JSON metadata instead of a friendly summary')
   .addOption(new Option('--wait <ms>', 'Alias for --post-load-delay').hideHelp())
-  .action((url: string, opts) => run('Page screenshot', async () => {
+  .action((url: string, opts) => runBrowser('Page screenshot', url, async () => {
     const delayRaw = opts.postLoadDelay ?? opts.wait;
     const postLoadDelayMs = delayRaw !== undefined ? parseInt(String(delayRaw), 10) : undefined;
     if (postLoadDelayMs !== undefined && (!Number.isFinite(postLoadDelayMs) || postLoadDelayMs < 0)) {

--- a/src/helpers/command.ts
+++ b/src/helpers/command.ts
@@ -4,6 +4,7 @@
  */
 
 import { error as clrError } from '../colors.js';
+import { ApiError } from '../api.js';
 
 /**
  * Wrap an async command action with standardized error handling.
@@ -16,5 +17,49 @@ export function run(label: string, action: () => Promise<void>): void {
   action().catch((err: any) => {
     console.error(clrError(`${label} failed: ${err.message}`));
     process.exit(1);
+  });
+}
+
+// A page command runs on a pooled headless-browser worker, so a timeout has two
+// very different causes that the bare server message ('[Browser command timed
+// out]') can't tell apart: the worker never handed back a session (infra) vs.
+// the worker ran but the page was slow to load/settle. An agent that can't tell
+// wastes turns re-probing the same dead capability.
+const isTimeout = (e: ApiError): boolean =>
+  e.statusCode === 504 || /timed out|timeout/i.test(e.message) || /TIMEOUT/i.test(e.code);
+
+// Slow-page timeouts already name an actionable cause (raise --wait, use
+// --wait-for, lighten the page), so leave their message untouched.
+const isSlowPage = (e: ApiError): boolean =>
+  /navigat|selector|wait[- ]?for|eval|did not (finish|settle|load)/i.test(`${e.code} ${e.message}`);
+
+/** Rewrite an ambiguous browser timeout into worker-outage guidance + the curl
+ *  fallback; pass every other error (incl. slow-page timeouts) through. */
+function classifyBrowserError(err: unknown, url: string): unknown {
+  if (!(err instanceof ApiError) || !isTimeout(err) || isSlowPage(err)) return err;
+  return new ApiError(
+    err.statusCode,
+    err.code,
+    'browser worker did not respond — usually a transient infra issue, not your page. ' +
+      'Retrying page commands is unlikely to help until the worker recovers. Verify the deploy directly:\n' +
+      `  curl -s -o /dev/null -w "%{http_code}\\n" ${url}\n` +
+      `then re-check per asset. (worker: ${err.message})`,
+  );
+}
+
+/**
+ * `run` for page/browser subcommands: enriches the ambiguous '[Browser command
+ * timed out]' so the agent can tell a worker outage from a slow page.
+ *
+ * Usage:
+ *   .action((url, opts) => runBrowser('Page inspect', url, async () => { ... }))
+ */
+export function runBrowser(label: string, url: string, action: () => Promise<void>): void {
+  run(label, async () => {
+    try {
+      await action();
+    } catch (err) {
+      throw classifyBrowserError(err, url);
+    }
   });
 }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -2,6 +2,6 @@
  * CLI helpers - shared patterns across all commands.
  */
 
-export { run } from './command.js';
+export { run, runBrowser } from './command.js';
 export { printOutput, printList, printResult } from './output.js';
 export { syncBeforeAction } from './sync.js';


### PR DESCRIPTION
## Rationale

When a `page` command (inspect/eval/screenshot) times out, it runs on a pooled
headless-browser worker — so a timeout has two very different causes that the bare
server message `[Browser command timed out]` cannot distinguish:

- **Worker outage (infra):** the pool never handed back a browser session. Transient;
  retrying `page` commands won't help until the worker recovers.
- **Slow page (nav):** the worker ran but the page didn't load/settle (or the
  `--wait-for` selector never appeared) in time. Actionable via `--wait` / `--wait-for`.

In the motivating run the agent could not tell these apart, so it retried `page inspect`
three times with small variations (plain, `--json`, `timeout 90`), then tried `eval` and
`screenshot` — ~6 wasted turns re-probing the same dead capability.

## Change

Add a `runBrowser()` wrapper (a sibling of `run()` in `src/helpers/command.ts`) used by
`page inspect`, `page eval`, and `page screenshot`. On an **ambiguous** browser timeout it
rewrites the message to name the likely worker-outage cause and suggest the curl fallback:

```
browser worker did not respond — usually a transient infra issue, not your page.
Retrying page commands is unlikely to help until the worker recovers. Verify the deploy directly:
  curl -s -o /dev/null -w "%{http_code}\n" <url>
then re-check per asset. (worker: <original message>)
```

Slow-page timeouts (whose messages already name an actionable cause — raise `--wait`, use
`--wait-for`, lighten the page) are passed through untouched, and non-timeout errors are
unchanged.

**Placement note:** the proposal targeted `src/commands/page.ts`, but having the page
subcommands import `page.ts` introduces a circular import (`page.ts` references the
subcommand `const`s before they initialize, breaking `page-screenshot` consumers). The
helper therefore lives next to `run()` in `src/helpers/command.ts`, which the subcommands
already import — same behavior, no cycle.

## Verification

- `npm run test:smoke` — all 13 `cli-cmd-page` tests pass; this change introduces **0** new
  failures (the 8 pre-existing failures — workflow / platform-mirror / tag-drift guards —
  are present on a clean `origin/main` and are unrelated to this change).

## Scorecard from the motivating run

```
success: true (db)
cost(usd-equiv): 0.0000  turns: 76
tokens: 81835 (14377 in / 67458 out)
tools: 37 total, 0 failed, retried: [Bash, Read, Write, Edit]
tool counts: Bash×16, Read×10, Write×9, Edit×2
timing: whole 600.3s, in-LLM 0.0s, in-tools ~600.3s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
