### PR TITLE
build: collapse generated files in PR diffs (linguist-generated)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Generated files — collapse in GitHub PR diffs ("file was hidden") and exclude
+# from language stats. Generated from the platform's docs by build scripts there;
+# never hand-edit:
+#   src/knowledge.ts      ← docs/knowledge/*.md via scripts/build-knowledge.ts
+#   src/provider-docs.ts  ← generated provider docs
+src/knowledge.ts linguist-generated=true
+src/provider-docs.ts linguist-generated=true


### PR DESCRIPTION
Adds `.gitattributes` marking the committed-but-generated files as `linguist-generated=true` so GitHub **auto-collapses** them in PR diffs and drops them from language stats:

- `src/knowledge.ts` — generated from the platform `docs/knowledge/*.md`
- `src/provider-docs.ts` — generated provider docs

Both already carry `do not edit` headers. This just keeps their machine-output diffs from padding PRs so reviewers focus on real code. Pairs with the platform-side `.gitattributes` PR and the GipRunner apply-prompt change (edit only the source `.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)