### PR TITLE
feat: Add a `--file <path>` option to `gipity sandbox run` to execute a script file directly

### DIFF
--- a/src/__tests__/cli-cmd-sandbox.test.ts
+++ b/src/__tests__/cli-cmd-sandbox.test.ts
@@ -1,5 +1,7 @@
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { runCliAsync } from './helpers/spawn-cli.js';
 import { startMockServer, MockServer } from './helpers/mock-server.js';
 import { makeAuthedHome, makeProjectDir } from './helpers/test-home.js';
@@ -56,6 +58,30 @@ test('gipity sandbox run auto-pulls output files to the local cwd', async () => 
   assert.ok(treeFetched, 'expected sandbox run to trigger a sync (files/tree fetch)');
   assert.match(r.stdout, /Output files synced to this directory/);
   assert.match(r.stdout, /result\.txt/);
+});
+
+test('gipity sandbox run --file reads the body and infers language from the extension', async () => {
+  mock.reset();
+  let posted: { code: string; language: string } | undefined;
+  mock.on('POST /projects/p_TestProj/sandbox/execute', async (req) => {
+    posted = req.body as { code: string; language: string };
+    return { body: { data: { exitCode: 0, stdout: 'ok', stderr: '', durationMs: 10, timedOut: false } } };
+  });
+  const d = makeProjectDir({ apiBase: mock.apiBase });
+  writeFileSync(join(d, 'build_report.py'), 'print("from file")\n');
+  const r = await runCliAsync(['--api-base', mock.apiBase, 'sandbox', 'run', '--file', 'build_report.py'], { env: { HOME: home }, cwd: d });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(posted?.code, 'print("from file")\n');
+  assert.equal(posted?.language, 'python');
+});
+
+test('gipity sandbox run rejects passing both inline code and --file', async () => {
+  mock.reset();
+  const d = makeProjectDir({ apiBase: mock.apiBase });
+  writeFileSync(join(d, 'x.js'), 'console.log(1)\n');
+  const r = await runCliAsync(['--api-base', mock.apiBase, 'sandbox', 'run', '--file', 'x.js', 'console.log(2)'], { env: { HOME: home }, cwd: d });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /not both/);
 });
 
 test('gipity sandbox run does NOT sync when there are no output files', async () => {

--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
-import { dirname, relative } from 'path';
+import { readFileSync } from 'fs';
+import { dirname, extname, relative } from 'path';
 import { post } from '../api.js';
 import { resolveProjectContext, getConfigPath } from '../config.js';
 import { sync } from '../sync.js';
@@ -30,9 +31,10 @@ export const sandboxCommand = new Command('sandbox')
   .description('Run code in a sandbox');
 
 sandboxCommand
-  .command('run <code>')
+  .command('run [code]')
   .description('Run code')
   .option('--language <language>', 'Language: js, py, or bash', 'js')
+  .option('--file <path>', 'Read the code body from a file instead of the inline <code> arg; --language is inferred from the extension when not given')
   .option('--timeout <seconds>', 'Execution timeout in seconds', '30')
   .option(
     '--input <path>',
@@ -61,6 +63,9 @@ Examples:
   $ gipity sandbox run --language python \\
       "import pandas as pd; print(pd.read_csv('data/sales.csv').describe())"
 
+  # Run a script file directly (language inferred from .py)
+  $ gipity sandbox run --file build_report.py
+
   # Surgical: only these files are mirrored in
   $ gipity sandbox run --language bash \\
       --input src/images/hero.png \\
@@ -74,9 +79,33 @@ Pre-installed: Python (pandas, numpy, matplotlib, Pillow, scipy, bs4),
 CLI tools (ImageMagick, FFmpeg, webp/cwebp, optipng, jq, pandoc, exiftool,
 GCC/Rust).
 `)
-  .action((code: string, opts) => run('Sandbox', async () => {
+  .action((code: string | undefined, opts, command: Command) => run('Sandbox', async () => {
     const { config } = await resolveProjectContext();
-    const language = LANG_MAP[opts.language] || opts.language;
+
+    if (code !== undefined && opts.file) {
+      console.error(clrError('Pass either an inline <code> arg or --file <path>, not both'));
+      process.exit(1);
+    }
+    if (code === undefined && !opts.file) {
+      console.error(clrError('Provide an inline <code> arg or --file <path>'));
+      process.exit(1);
+    }
+
+    let source = code;
+    if (opts.file) {
+      try {
+        source = readFileSync(opts.file, 'utf8');
+      } catch {
+        console.error(clrError(`Cannot read file: ${opts.file}`));
+        process.exit(1);
+      }
+    }
+
+    // Infer language from the file extension unless --language was given explicitly.
+    const fromExt = opts.file && command.getOptionValueSource('language') === 'default'
+      ? LANG_MAP[extname(opts.file).slice(1).toLowerCase()]
+      : undefined;
+    const language = fromExt || LANG_MAP[opts.language] || opts.language;
 
     if (!['javascript', 'python', 'bash'].includes(language)) {
       console.error(clrError(`Invalid language: ${opts.language}. Use: js, py, or bash`));
@@ -98,7 +127,7 @@ GCC/Rust).
         autoMirrorSkipped?: { reason: string; totalBytes: number };
       };
     }>(`/projects/${config.projectGuid}/sandbox/execute`, {
-      code,
+      code: source,
       language,
       timeout: isNaN(timeout) ? 30 : timeout,
       input_files: opts.input,

--- a/src/flag-aliases.ts
+++ b/src/flag-aliases.ts
@@ -65,8 +65,19 @@ function collectRealFlags(argv: string[], program: Command): Set<string> {
   let cmd: Command = program;
   const chain: Command[] = [program];
 
-  for (const tok of args) {
-    if (tok.startsWith('-')) break; // first flag ends command resolution
+  // Root value-options (e.g. `--api-base <url>`) may legitimately precede the
+  // subcommand; skip them (and their value token) rather than ending resolution
+  // there, so a command's own flag is still discovered when a global flag leads.
+  const rootValueFlags = new Set(
+    program.options.filter(o => o.long && o.required).map(o => o.long as string),
+  );
+
+  for (let i = 0; i < args.length; i++) {
+    const tok = args[i];
+    if (tok.startsWith('-')) {
+      if (!tok.includes('=') && rootValueFlags.has(tok)) i++; // consume its value
+      continue;
+    }
     const next = cmd.commands.find(c => c.name() === tok || c.aliases().includes(tok));
     if (!next) break;
     cmd = next;


### PR DESCRIPTION
## Rationale

To run a multi-line Python report generator, the agent wrote `build_report.py` then invoked `gipity sandbox run --language python ... "$(cat build_report.py)"`. The `$(cat ...)` shell-substitution workaround is fragile (quoting/escaping risk) and only works because the agent hand-assembled it. A first-class way to point at a script file is cleaner and safer.

## Change

- Add `--file <path>` to `gipity sandbox run` (mutually exclusive with the positional `<code>` arg). It reads the file contents as the code body.
- `--language` is inferred from the file extension (`.py`→python, `.js`→javascript, `.sh`→bash) when not given explicitly; an explicit `--language` still wins.
- Documented inline in the command's `--help` examples.

```
gipity sandbox run --file build_report.py            # language inferred from .py
gipity sandbox run --file run.sh --language bash     # explicit language wins
```

### Incidental fix

While wiring this up I hit a latent bug in the flag-alias resolver (`src/flag-aliases.ts`). There is a global hidden alias `--file` → `--output` (a plausible LLM guess for output-file flags on `generate`/`page screenshot`). The resolver is designed to leave an alias untouched when the target command declares that flag for real — but `collectRealFlags` stopped command resolution at the *first* flag, so a leading global value-option (`gipity --api-base <url> sandbox run --file …`) hid the subcommand's real flags and let the alias hijack `--file`. It now skips leading global value-options (and their value token) before resolving the subcommand, so a command's own flag always wins regardless of arg order. This also fixes the documented `--from` / `workflow create` collision case when `--api-base` leads.

## Tests

Added coverage in `cli-cmd-sandbox.test.ts` (`--file` reads body + infers language; rejects passing both inline code and `--file`). Full `npm run test:smoke` passes (431/431).

> Note: no generated `.ts` files are involved — this is the standalone `GipityAI/cli` repo, and the `sandbox-tools` skill doc lives in the separate `platform` repo, so the user-facing documentation of `--file` is in the command's own `--help` text here.

## Scorecard from the motivating run

```
success: true (db)
cost(usd-equiv): 0.0000  turns: 15
tokens: 16986 (9225 in / 7761 out)
tools: 6 total, 0 failed, retried: [Bash, Write]
tool counts: Bash×4, Write×2
timing: whole 75.2s, in-LLM 0.0s, in-tools ~75.2s
```

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)