### PR TITLE
Fix relay daemon trapped in restart loop by stale pid file

### DIFF
--- a/src/__tests__/relay-state.test.ts
+++ b/src/__tests__/relay-state.test.ts
@@ -8,6 +8,7 @@ import { statSync, existsSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
+import { spawn } from 'node:child_process';
 
 /** Each test gets a fresh HOME and re-imports state with a cache-busting query. */
 async function fresh(): Promise<{ state: typeof import('../relay/state.js'); home: string }> {
@@ -92,5 +93,52 @@ describe('relay state: corrupted file recovery', () => {
     // And we can still save cleanly on top of it.
     state.setPaused(true);
     assert.equal(state.loadState().paused, true);
+  });
+});
+
+describe('relay daemon pid lock: stale-file recovery', () => {
+  // Regression: a leftover pid file from an unclean exit used to trap the daemon
+  // in a permanent restart loop ("another daemon is already running") because
+  // boot bailed on EEXIST without checking the recorded PID was actually alive.
+  // isDaemonRunning() must clear a stale file so the next start can take the lock.
+
+  it('clears a stale pid file (dead process) and reports not-running', async () => {
+    const { state, home } = await fresh();
+    const dir = join(home, '.gipity');
+    mkdirSync(dir, { recursive: true });
+
+    // A real, now-dead pid: spawn a child, kill it, wait for it to exit.
+    const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60000)']);
+    const deadPid = child.pid!;
+    await new Promise<void>(res => { child.once('exit', () => res()); child.kill('SIGKILL'); });
+
+    state.writeDaemonPid(deadPid);
+    const pidPath = join(dir, 'relay.pid');
+    assert.ok(existsSync(pidPath), 'precondition: pid file written');
+
+    assert.equal(state.isDaemonRunning(), false, 'dead pid → not running');
+    assert.equal(existsSync(pidPath), false, 'stale pid file should be cleared');
+  });
+
+  it('clears a corrupt pid file and reports not-running', async () => {
+    const { state, home } = await fresh();
+    const dir = join(home, '.gipity');
+    mkdirSync(dir, { recursive: true });
+    const pidPath = join(dir, 'relay.pid');
+    writeFileSync(pidPath, 'not-a-pid');
+
+    assert.equal(state.isDaemonRunning(), false);
+    assert.equal(existsSync(pidPath), false, 'corrupt pid file should be cleared');
+  });
+
+  it('keeps the pid file and reports running for a live process', async () => {
+    const { state, home } = await fresh();
+    const dir = join(home, '.gipity');
+    mkdirSync(dir, { recursive: true });
+    state.writeDaemonPid(process.pid); // our own (live) pid
+    const pidPath = join(dir, 'relay.pid');
+
+    assert.equal(state.isDaemonRunning(), true, 'live pid → running');
+    assert.ok(existsSync(pidPath), 'live pid file must NOT be cleared');
   });
 });

--- a/src/relay/daemon.ts
+++ b/src/relay/daemon.ts
@@ -236,12 +236,13 @@ export async function run(opts: DaemonOptions = {}): Promise<number> {
 
   if (opts.maxRunMs) setTimeout(() => shutdown('maxRunMs'), opts.maxRunMs).unref();
 
-  // Take the PID lock. If another daemon already holds it, exit clean -
-  // the caller (usually `gipity claude`'s auto-start) is racing us.
-  try {
-    state.writeDaemonPid(process.pid);
-  } catch (err: any) {
-    log('info', 'another daemon is already running - exiting', { err: err?.message });
+  // Take the PID lock. Only a *live* daemon should block us: a leftover pid file
+  // from an unclean exit (container SIGKILL'd, or `--restart` brought us back on
+  // the same filesystem) must not trap us in a permanent restart loop.
+  // isDaemonRunning() validates the recorded PID is actually alive and clears
+  // the file if it's stale, so writeDaemonPid below can then take the lock.
+  if (state.isDaemonRunning()) {
+    log('info', 'another daemon is already running - exiting');
     if (opts.verbose) {
       process.stderr.write(
         'Another relay daemon is already running (likely the autostarted one).\n' +
@@ -249,6 +250,13 @@ export async function run(opts: DaemonOptions = {}): Promise<number> {
         'or tail the existing daemon:  gipity relay log -f\n',
       );
     }
+    return 0;
+  }
+  try {
+    state.writeDaemonPid(process.pid);
+  } catch (err: any) {
+    // Lost a genuine race with another daemon starting at the same instant.
+    log('info', 'lost pid-lock race with another daemon - exiting', { err: err?.message });
     return 0;
   }
   const releasePid = () => state.clearDaemonPid();

--- a/src/relay/state.ts
+++ b/src/relay/state.ts
@@ -153,7 +153,8 @@ export function isDaemonRunning(): boolean {
   try {
     const raw = readFileSync(RELAY_PID_FILE, 'utf-8').trim();
     const pid = parseInt(raw, 10);
-    if (!pid || isNaN(pid)) return false;
+    // A corrupt/empty pid file is stale - clear it so it can't trap a restart.
+    if (!pid || isNaN(pid)) { try { unlinkSync(RELAY_PID_FILE); } catch { /* ignore */ } return false; }
     // `kill 0` sends no signal but checks if the PID is addressable.
     process.kill(pid, 0);
     return true;


### PR DESCRIPTION
## Problem
The relay daemon takes a pid lock at boot via `writeDaemonPid` (exclusive `wx` flag). On an unclean exit the pid file is left behind, and `--restart unless-stopped` brings the daemon back on the **same container filesystem** — so every restart hit `EEXIST`, logged `another daemon is already running - exiting`, and looped forever.

Observed live on the hosted relay-host container (`Restarting (0)` every ~60s):
```
another daemon is already running - exiting  err=EEXIST ... open '/home/relay/.gipity/relay.pid'
```

## Fix
- Boot now calls `isDaemonRunning()` **before** `writeDaemonPid`. That validates the recorded PID is actually alive (`process.kill(pid, 0)`) and clears the file if it's stale — so only a *live* daemon blocks startup. The write is still guarded for the genuine same-instant race.
- `isDaemonRunning()` also clears a **corrupt/empty** pid file (previously it returned `false` without unlinking, which could trap startup the same way).

## Tests
`relay-state.test.ts` adds coverage for stale (dead pid), corrupt, and live-pid cases — asserting the file is cleared when stale and kept when live. Full `tsc` + relay-state/relay-daemon suites pass (15/15).

Note: a *recreate* (fresh FS) already sidesteps this — but the daemon should self-recover on a plain restart, which this delivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)