### PR TITLE
fix: make test filtering actionable

### DIFF
--- a/src/__tests__/cli-cmd-test.test.ts
+++ b/src/__tests__/cli-cmd-test.test.ts
@@ -38,6 +38,60 @@ test('gipity test --no-sync runs and prints pass/fail summary', async () => {
   assert.doesNotMatch(r.stdout, /undefined/);
 });
 
+test('gipity test --filter <path> runs tests for that path', async () => {
+  mock.reset();
+  mock.on('POST /projects/p_TestProj/test/run', { body: { data: { runGuid: RUN_GUID, status: 'running' } } });
+  mock.on(`GET /projects/p_TestProj/test/status/${RUN_GUID}`, { body: { data: {
+    runGuid: RUN_GUID, status: 'passed', total: 1, passed: 1, failed: 0, skipped: 0,
+    durationMs: 321, totalFiles: 1, completedFiles: 1,
+    startedAt: '2026-05-01T10:00:00Z', updatedAt: '2026-05-01T10:00:01Z', finishedAt: '2026-05-01T10:00:01Z',
+    results: [
+      { path: 'api/library.test.js', name: 'library endpoint', status: 'passed', durationMs: 30, retryCount: 0, isFlaky: false },
+    ],
+  } } });
+
+  const r = await fresh(['test', '--filter', 'api/library', '--no-sync']);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /Running tests: api\/library/);
+  assert.deepEqual(mock.requests()[0]?.body, { filterPath: 'api/library', timeout: 30000, retry: 0 });
+});
+
+test('gipity test <path> still sends the path as filterPath', async () => {
+  mock.reset();
+  mock.on('POST /projects/p_TestProj/test/run', { body: { data: { runGuid: RUN_GUID, status: 'running' } } });
+  mock.on(`GET /projects/p_TestProj/test/status/${RUN_GUID}`, { body: { data: {
+    runGuid: RUN_GUID, status: 'passed', total: 1, passed: 1, failed: 0, skipped: 0,
+    durationMs: 321, totalFiles: 1, completedFiles: 1,
+    startedAt: '2026-05-01T10:00:00Z', updatedAt: '2026-05-01T10:00:01Z', finishedAt: '2026-05-01T10:00:01Z',
+    results: [
+      { path: 'api/library.test.js', name: 'library endpoint', status: 'passed', durationMs: 30, retryCount: 0, isFlaky: false },
+    ],
+  } } });
+
+  const r = await fresh(['test', 'api/library', '--no-sync']);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /Running tests: api\/library/);
+  assert.deepEqual(mock.requests()[0]?.body, { filterPath: 'api/library', timeout: 30000, retry: 0 });
+});
+
+test('gipity test <path> fails clearly when no tests match', async () => {
+  mock.reset();
+  mock.on('POST /projects/p_TestProj/test/run', { body: { data: { runGuid: RUN_GUID, status: 'running' } } });
+  mock.on(`GET /projects/p_TestProj/test/status/${RUN_GUID}`, { body: { data: {
+    runGuid: RUN_GUID, status: 'passed', total: 0, passed: 0, failed: 0, skipped: 0,
+    durationMs: 77, totalFiles: 0, completedFiles: 0,
+    startedAt: '2026-05-01T10:00:00Z', updatedAt: '2026-05-01T10:00:01Z', finishedAt: '2026-05-01T10:00:01Z',
+    results: [],
+  } } });
+
+  const r = await fresh(['test', 'api/library', '--no-sync']);
+
+  assert.equal(r.status, 1);
+  assert.match(r.stdout, /No tests matched filter: api\/library/);
+});
+
 test('gipity test status <runGuid> shows current run state', async () => {
   mock.reset();
   mock.on(`GET /projects/p_TestProj/test/status/${RUN_GUID}`, { body: { data: {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -109,13 +109,15 @@ async function pollTestStatus(projectGuid: string, runGuid: string, opts: { json
 export const testCommand = new Command('test')
   .description('Run tests')
   .argument('[path]', 'Test path filter (e.g. "api", "e2e/portal")')
+  .option('--filter <path>', 'Alias for the positional test path filter')
   .option('--timeout <ms>', 'Per-test timeout in ms', '30000')
   .option('--retry <n>', 'Retry failed tests N times', '0')
   .option('--no-sync', 'Skip sync-up before tests')
   .option('--json', 'Output as JSON')
-  .action((filterPath: string | undefined, opts) => run('Test', async () => {
+  .action((pathFilter: string | undefined, opts) => run('Test', async () => {
       const config = requireConfig();
       await syncBeforeAction(opts);
+      const filterPath = opts.filter || pathFilter;
 
       if (!opts.json) {
         console.log(bold(`Running tests: ${filterPath || 'all'}`));
@@ -155,6 +157,11 @@ export const testCommand = new Command('test')
       // (pollTestStatus already printed results incrementally)
 
       console.log('');
+
+      if (filterPath && data.total === 0 && data.results.length === 0) {
+        console.log(clrError(`No tests matched filter: ${filterPath}`));
+        process.exit(1);
+      }
 
       // Summary
       const parts: string[] = [];


### PR DESCRIPTION
## Summary
- Add `--filter <path>` as an alias for the existing positional `gipity test <path>` filter.
- Preserve the selected filter in the `/test/run` request payload.
- Return a clear nonzero no-matches result when a non-empty filter completes without test results.
- Add focused CLI coverage for the flag alias, positional filter payload, and no-match behavior.

## Linked issue
Fixes #34

## Problem
`gipity test --filter ...` was a natural way to target one path, but it fell through to generic help output. The supported positional filter could also produce an empty success-like run when no tests matched, which made targeted verification hard to trust.

## Fix
The test command now accepts `--filter <path>` and feeds either the flag value or positional path into the existing `filterPath` payload. If a non-empty filter produces zero reported tests, the command prints an actionable message and exits nonzero.

## Tests
- `npm run build && node --test dist/__tests__/cli-cmd-test.test.js` - pass, 6/6 focused tests.
- `git diff --check HEAD~1..HEAD` - pass.
- `npm test` - the changed `cli-cmd-test` suite passes inside the run; the full standalone-clone suite still has 4 unrelated baseline/environment failures outside this change.

## Risk notes
- Scope is limited to `gipity test` CLI parsing/output plus focused tests.
- I did not run live Gipity platform or e2e commands; the local mock-server tests cover this CLI request path.
- Upstream `main` moved after the branch was prepared, but the new upstream commit only touches `src/knowledge.ts`; merge-tree reports no conflict with this branch.