### PR TITLE
feat: Isolate `gipity test` writes from the live DB (per-run test data + teardown), or document that ctx.fn.call mutates production

### DIFF
--- a/GIPITY-SKILLS.md
+++ b/GIPITY-SKILLS.md
@@ -116,7 +116,20 @@ test('get-items returns items', async (ctx) => {
 - `ctx.fn.call(name, params)` - call a deployed function
 - `test()` and `assert` are provided as globals by the harness - do NOT `import` them
 - Write tests for every new function by default; use judgment for trivial glue code or throwaway experiments
-- Tests run in sandboxed containers - no raw DB access
+- The test *code* is sandboxed (no direct DB or filesystem access), but `ctx.fn.call` hits your **real deployed functions against the real project DB**. Writes persist after the run - there is no auto-rollback or teardown. Clean up rows you create in the same test (`try/finally`), and use a unique key per run so re-runs don't collide:
+
+```js
+test('save + delete round-trips', async (ctx) => {
+    const key = `test-${Date.now()}`;
+    const saved = await ctx.fn.call('save-receipt', { title: key });
+    try {
+        const list = await ctx.fn.call('list-receipts', {});
+        assert.ok(list.receipts.some(r => r.title === key));
+    } finally {
+        await ctx.fn.call('delete-receipt', { short_guid: saved.short_guid });
+    }
+});
+```
 
 ### API Dev Workflow
 


### PR DESCRIPTION
## Problem

`gipity test` runs each `*.test.js` through `ctx.fn.call(name, params)`, which invokes the user's **real deployed function over HTTP against the real project DB** (the harness injects a public app token and POSTs to `/api/<app>/fn/<name>` — see `platform/server/src/services/test-runner.ts`). The container that runs the *test code* is sandboxed (non-root, no direct DB or filesystem access), but the function it calls writes to production data. Nothing rolls back or tears down those rows.

The CLI docs said only **"Tests run in sandboxed containers - no raw DB access"**, which an agent reasonably reads as "isolated from production." In the triggering run, a save/list/delete test left receipt rows behind; the agent had to hand-curl `delete-receipt` against `a.gipity.ai` to clean up before showing an empty vault — and the run still scored `success:false (db)`.

## Root cause / fix

The platform is working as designed — these are integration tests against the real deployed stack — so the defect is the **false isolation promise** in the docs, not the runner. Fixed the CLI test docs (`GIPITY-SKILLS.md`) to state the actual behavior: the test code is sandboxed, but `ctx.fn.call` mutates the real project DB and writes persist (no auto-rollback/teardown). Added the missing teardown pattern: clean up rows you create in the same test via `try/finally`, using a unique per-run key so re-runs don't collide. The example mirrors the exact save/list/delete shape from the failing run.

This is the "document that ctx.fn.call mutates production" path from the issue title. True per-run DB isolation would be a server-side test-harness change in the `platform` repo (out of scope for this CLI PR).

## Note for reviewer

The same misleading line ("Tests run in sandboxed containers - no raw database access") also lives in the canonical integration guide `platform/docs/knowledge/cli-integration.md` (which generates `CLAUDE.md`) and in `platform/docs/skills/app-development.md`. Those are in the `platform` repo and should get the same clarification in a sibling PR — this PR only touches the hand-maintained CLI doc `cli/GIPITY-SKILLS.md`.

## Scorecard from the motivating run

```
success: false (db)
cost(usd-equiv): 0.0000  turns: 85
tokens: 88282 (13892 in / 74390 out)
tools: 44 total, 2 failed, retried: [Bash, Write, Edit, Read]
tool counts: Bash×27, Write×12, Edit×2, Read×3
timing: whole 473.6s, in-LLM 0.0s, in-tools ~473.6s
```

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
