### PR TITLE
feat: `gipity test` produces no progress output during a long LLM-backed run — the agent went blind at the verification step and the run never completed

### DIFF
--- a/src/__tests__/cli-cmd-test.test.ts
+++ b/src/__tests__/cli-cmd-test.test.ts
@@ -92,6 +92,34 @@ test('gipity test <path> fails clearly when no tests match', async () => {
   assert.match(r.stdout, /No tests matched filter: api\/library/);
 });
 
+test('gipity test emits newline heartbeats while running (non-TTY/background)', async () => {
+  mock.reset();
+  mock.on('POST /projects/p_TestProj/test/run', { body: { data: { runGuid: RUN_GUID, status: 'running' } } });
+  let polls = 0;
+  mock.on(`GET /projects/p_TestProj/test/status/${RUN_GUID}`, () => {
+    polls++;
+    const done = polls >= 3;  // stay "running" for the first couple of polls
+    return { body: { data: {
+      runGuid: RUN_GUID, status: done ? 'passed' : 'running',
+      total: 1, passed: done ? 1 : 0, failed: 0, skipped: 0,
+      durationMs: done ? 1234 : 0, totalFiles: 1, completedFiles: done ? 1 : 0,
+      startedAt: '2026-05-01T10:00:00Z', updatedAt: '2026-05-01T10:00:01Z',
+      finishedAt: done ? '2026-05-01T10:00:01Z' : null,
+      results: done ? [
+        { path: 'api/health.test.js', name: 'health endpoint', status: 'passed', durationMs: 50, retryCount: 0, isFlaky: false },
+      ] : [],
+    } } };
+  });
+  // CLI stdout is piped here (not a TTY), so the in-place \r progress is suppressed
+  // and the heartbeat path must produce visible newline output instead.
+  const r = await fresh(['test', '--no-sync']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /still running/);
+  assert.match(r.stdout, /elapsed/);
+  assert.match(r.stdout, /1 passed/);
+  assert.doesNotMatch(r.stdout, /undefined/);
+});
+
 test('gipity test status <runGuid> shows current run state', async () => {
   mock.reset();
   mock.on(`GET /projects/p_TestProj/test/status/${RUN_GUID}`, { body: { data: {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -37,6 +37,10 @@ interface TestStatusResponse {
   };
 }
 
+// Heartbeat cadence for non-TTY runs (background/piped output, e.g. a watching agent).
+const HEARTBEAT_MS = 10000;  // emit a newline progress line at least this often
+const LONG_RUN_MS = 60000;   // after this, print a one-time "not hung" + faster-path hint
+
 async function pollTestStatus(projectGuid: string, runGuid: string, opts: { json?: boolean }): Promise<TestStatusResponse['data']> {
   // Adaptive polling: fast at first (tests often finish quickly with warm pool),
   // then back off for long-running suites.
@@ -48,6 +52,9 @@ async function pollTestStatus(projectGuid: string, runGuid: string, opts: { json
     return 3000;                        // after 20s: poll every 3s
   };
   let lastResultCount = 0;
+  const isTTY = !!process.stdout.isTTY;
+  let lastHeartbeat = 0;       // 0 => emit the first heartbeat immediately (non-TTY)
+  let longRunHintShown = false;
 
   while (true) {
     const res = await get<TestStatusResponse>(`/projects/${projectGuid}/test/status/${runGuid}`);
@@ -90,13 +97,36 @@ async function pollTestStatus(projectGuid: string, runGuid: string, opts: { json
       return data;
     }
 
-    // Show progress indicator (overwrite in-place) - only in real terminals
-    if (!opts.json && process.stdout.isTTY) {
-      if (data.totalFiles === 0) {
-        process.stdout.write(`\r  ${muted('Starting...')}          `);
+    if (!opts.json) {
+      if (isTTY) {
+        // Real terminal: overwrite a single in-place progress line.
+        if (data.totalFiles === 0) {
+          process.stdout.write(`\r  ${muted('Starting...')}          `);
+        } else {
+          const pct = Math.round((data.completedFiles / data.totalFiles) * 100);
+          process.stdout.write(`\r  ${muted(`${data.completedFiles}/${data.totalFiles} files (${pct}%)`)}`);
+        }
       } else {
-        const pct = Math.round((data.completedFiles / data.totalFiles) * 100);
-        process.stdout.write(`\r  ${muted(`${data.completedFiles}/${data.totalFiles} files (${pct}%)`)}`);
+        // Non-TTY (background/piped, e.g. a watching agent): a \r line never
+        // shows up in a captured file, so emit periodic newline heartbeats.
+        // Time-based so the file always grows — lets a watcher tell a slow run
+        // from a hung one, and gives elapsed time to budget against.
+        const now = Date.now();
+        if (now - lastHeartbeat >= HEARTBEAT_MS) {
+          lastHeartbeat = now;
+          const elapsed = Math.round((now - startTime) / 1000);
+          const progress = data.totalFiles === 0
+            ? 'starting up'
+            : `${data.completedFiles}/${data.totalFiles} files`;
+          const tally = data.passed + data.failed > 0
+            ? ` (${data.passed} passed${data.failed > 0 ? `, ${data.failed} failed` : ''})`
+            : '';
+          console.log(muted(`  … still running — ${progress}${tally}, ${elapsed}s elapsed`));
+          if (now - startTime >= LONG_RUN_MS && !longRunHintShown) {
+            longRunHintShown = true;
+            console.log(muted('  Note: progressing, not hung. LLM-backed tests can take minutes. To verify one function fast, use `gipity fn call <name>`; narrow this suite with `gipity test <path>`.'));
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Problem

Two related frictions on the test/verification surface, both rooted in the same defect: **`gipity test` emits no progress while running unless stdout is a TTY.**

1. **Blind background polling.** A watching agent runs the suite as a background task with stdout piped to a file (non-TTY). The poll loop only wrote a progress indicator behind `process.stdout.isTTY`, and it used an in-place `\r` line that never appears in a captured file anyway. So the file stayed at one line until the first test completed — and with slow LLM-backed tests, that never happened within budget. The agent got `the file ... has 1 lines` then `Wasted call — file unchanged`, with no way to distinguish a hung run from a slow-but-progressing one, and spent its last turns polling nothing.

2. **A slow LLM-backed run ate the session with no guidance.** The agent wrote a sensible integration test that makes real LLM calls; it ran past the ~1305s budget and verification never completed. Nothing told the agent the run was progressing rather than stuck, or pointed at a faster verification path.

## Root-cause fix

In `src/commands/test.ts`, `pollTestStatus` now branches on TTY:

- **TTY**: unchanged in-place `\r` progress.
- **Non-TTY** (background/piped — exactly how an agent watches it): emit **time-based newline heartbeats** every 10s showing file progress, pass/fail tally, and elapsed seconds. The captured file always grows, so a watcher can tell slow from hung and has elapsed time to budget against.
- After 60s, print a **one-time note** that the run is progressing (not hung) and point to faster paths: `gipity fn call <name>` for a single function, `gipity test <path>` to narrow the suite. This delivers the missing guidance (friction #2) at the point of use, in the platform itself, rather than in a doc that trains agents to work around the gap.

Per-test result lines already printed in both modes; this fills the gap before/between completions during long tests.

Docs angle: the testing/app-dev skill docs live in the `platform` repo (`docs/skills/*.md`), unreachable from this isolated CLI worktree. The CLI-side hint is the stronger fix regardless — it surfaces guidance exactly when a run is slow instead of relying on a pre-read doc.

## Tests

Added a non-TTY heartbeat test (mock returns `running` for the first polls, then `passed`) asserting heartbeat output appears. Full `npm run test:smoke` passes except one pre-existing, unrelated failure (`cli-cmd-text` reads `platform/packages/shared/src/text-analysis.ts`, absent in this single-repo worktree).

## Scorecard

(no scorecard — human-filed or legacy issue)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)