### PR TITLE
feat: back off test heartbeat cadence on long runs (10s → 30s → 60s)

### DIFF
--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -37,9 +37,8 @@ interface TestStatusResponse {
   };
 }
 
-// Heartbeat cadence for non-TTY runs (background/piped output, e.g. a watching agent).
-const HEARTBEAT_MS = 10000;  // emit a newline progress line at least this often
-const LONG_RUN_MS = 60000;   // after this, print a one-time "not hung" + faster-path hint
+// Long-run hint for non-TTY runs: after this, print a one-time "not hung" + faster-path hint.
+const LONG_RUN_MS = 60000;
 
 async function pollTestStatus(projectGuid: string, runGuid: string, opts: { json?: boolean }): Promise<TestStatusResponse['data']> {
   // Adaptive polling: fast at first (tests often finish quickly with warm pool),
@@ -50,6 +49,15 @@ async function pollTestStatus(projectGuid: string, runGuid: string, opts: { json
     if (elapsed < 5000) return 300;    // first 5s: poll every 300ms
     if (elapsed < 20000) return 1000;  // next 15s: poll every 1s
     return 3000;                        // after 20s: poll every 3s
+  };
+  // Heartbeat cadence for non-TTY runs (background/piped output, e.g. a watching
+  // agent): every line is re-read by the watcher, and on long LLM-backed suites
+  // nothing changes second-to-second — so back off like getPollInterval does.
+  const getHeartbeatInterval = () => {
+    const elapsed = Date.now() - startTime;
+    if (elapsed < 120000) return 10000;  // first 2 min: every 10s
+    if (elapsed < 300000) return 30000;  // to 5 min: every 30s
+    return 60000;                         // after 5 min: every 60s
   };
   let lastResultCount = 0;
   const isTTY = !!process.stdout.isTTY;
@@ -112,7 +120,7 @@ async function pollTestStatus(projectGuid: string, runGuid: string, opts: { json
         // Time-based so the file always grows — lets a watcher tell a slow run
         // from a hung one, and gives elapsed time to budget against.
         const now = Date.now();
-        if (now - lastHeartbeat >= HEARTBEAT_MS) {
+        if (now - lastHeartbeat >= getHeartbeatInterval()) {
           lastHeartbeat = now;
           const elapsed = Math.round((now - startTime) / 1000);
           const progress = data.totalFiles === 0


### PR DESCRIPTION
## Problem

The non-TTY heartbeats added in #47 fire every 10s for the entire run. On a 20-minute LLM-backed suite that's ~120 near-identical lines, and a watching agent re-reads all of them on every poll of the captured output file.

## Fix

Replace the fixed `HEARTBEAT_MS` with a `getHeartbeatInterval()` that backs off with elapsed time — 10s for the first 2 minutes, 30s to 5 minutes, 60s after — mirroring the existing `getPollInterval` backoff in the same function. The same 20-minute run now emits ~25 heartbeat lines with no loss of signal: at those timescales nothing changes second-to-second, and per-test result lines still print the moment each test completes.

## Tests

`npm run test:smoke`: 463/464 pass, including the existing non-TTY heartbeat test (early-phase cadence is unchanged, so it covers this path). The one failure is the pre-existing environmental `cli-cmd-text` sibling-path issue, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)