### PR TITLE
fix: `gipity page inspect` flags non-reproducible cold-load console errors with a message-less, misleading hint, triggering a long false-positive debugging detour

### DIFF
--- a/src/__tests__/cli-cmd-page.test.ts
+++ b/src/__tests__/cli-cmd-page.test.ts
@@ -120,6 +120,54 @@ test('gipity page inspect --json emits the raw inspect bundle', async () => {
   assert.equal(parsed.overflow.overflowX, false);
 });
 
+// A console error that recurs on the re-probe is a real defect — reported as-is.
+test('gipity page inspect re-probes on console errors and reports reproducible ones', async () => {
+  mock.reset();
+  let calls = 0;
+  mock.on('POST /tools/browser/inspect', () => {
+    calls++;
+    return { body: { data: { ...baseBundle, console: ['error: ReferenceError: foo is not defined'] } } };
+  });
+  const r = await run(['page', 'inspect', 'https://example.com']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(calls, 2, 'inspect re-probes once when errors are present');
+  assert.match(r.stdout, /ReferenceError: foo is not defined/);
+  assert.doesNotMatch(r.stdout, /Transient console errors/);
+});
+
+// A console error gone on the re-probe is a cold-load transient — demoted, not flagged.
+test('gipity page inspect demotes a non-reproducible console error to transient', async () => {
+  mock.reset();
+  let calls = 0;
+  mock.on('POST /tools/browser/inspect', () => {
+    calls++;
+    const console = calls === 1
+      ? ['error: (message-less error — details hidden by the browser\'s cross-origin policy)']
+      : [];
+    return { body: { data: { ...baseBundle, console } } };
+  });
+  const r = await run(['page', 'inspect', 'https://example.com']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(calls, 2);
+  assert.match(r.stdout, /Transient console errors/);
+  assert.match(r.stdout, /not reproduced on re-probe/);
+});
+
+test('gipity page inspect --json moves transient errors to transientConsole', async () => {
+  mock.reset();
+  let calls = 0;
+  mock.on('POST /tools/browser/inspect', () => {
+    calls++;
+    const console = calls === 1 ? ['error: (message-less error)'] : [];
+    return { body: { data: { ...baseBundle, console } } };
+  });
+  const r = await run(['page', 'inspect', 'https://example.com', '--json']);
+  assert.equal(r.status, 0, r.stderr);
+  const parsed = JSON.parse(r.stdout.trim());
+  assert.deepEqual(parsed.console, []);
+  assert.deepEqual(parsed.transientConsole, ['error: (message-less error)']);
+});
+
 // Eval is async: POST returns a job id, the CLI polls GET until the job is
 // done. The mock returns a fixed evalJobId and the matching done record.
 test('gipity page eval prints the serialized expression result', async () => {

--- a/src/commands/page-inspect.ts
+++ b/src/commands/page-inspect.ts
@@ -25,7 +25,11 @@ interface DebugBundle {
     amount: number;
     culprits: { tag: string; cls: string; left: number; right: number; width: number }[];
   } | null;
+  transientConsole?: string[];
 }
+
+/** A console line is an error-level entry (page error or console.error). */
+const isErrorLine = (line: string): boolean => /^error:/i.test(line);
 
 function shortUrl(url: string, truncate = true, maxLen = 100): string {
   let result: string;
@@ -69,20 +73,39 @@ export const pageInspectCommand = new Command('inspect')
     const truncate = opts.truncate !== false;
     const showAll = opts.all === true;
 
-    const res = await post<{ data: DebugBundle }>(
-      `/tools/browser/inspect`,
-      {
-        url, waitMs,
-        waitForSelector: opts.waitFor || undefined,
-        waitForTimeoutMs: opts.waitFor ? waitForTimeoutMs : undefined,
-        fakeMedia: opts.fakeMedia || undefined,
-      },
-    );
+    const inspectBody = {
+      url, waitMs,
+      waitForSelector: opts.waitFor || undefined,
+      waitForTimeoutMs: opts.waitFor ? waitForTimeoutMs : undefined,
+      fakeMedia: opts.fakeMedia || undefined,
+    };
+
+    const res = await post<{ data: DebugBundle }>(`/tools/browser/inspect`, inspectBody);
 
     const b = res.data;
 
+    // Self-verify console errors before flagging them. A freshly-deployed page's
+    // first hit can throw a one-time, non-reproducible error — typically a
+    // cross-origin "Script error." with no message/stack from a CDN asset still
+    // propagating — and reporting it as a real defect sends agents chasing a
+    // phantom. So when the first probe reports error-level console lines, re-probe
+    // once (the sticky session is now warm) and keep only the errors that recur;
+    // errors seen on a single probe are surfaced separately as transient noise.
+    let transientErrors: string[] = [];
+    if ((b.console || []).some(isErrorLine)) {
+      try {
+        const verify = await post<{ data: DebugBundle }>(`/tools/browser/inspect`, inspectBody);
+        const recurring = new Set((verify.data.console || []).filter(isErrorLine));
+        transientErrors = (b.console || []).filter((l) => isErrorLine(l) && !recurring.has(l));
+        b.console = (b.console || []).filter((l) => !isErrorLine(l) || recurring.has(l));
+      } catch {
+        // Re-probe failed (timeout / browser error) — report the first probe's
+        // console as-is rather than hiding anything.
+      }
+    }
+
     if (opts.json) {
-      console.log(JSON.stringify(b));
+      console.log(JSON.stringify(transientErrors.length ? { ...b, transientConsole: transientErrors } : b));
       return;
     }
 
@@ -114,6 +137,15 @@ export const pageInspectCommand = new Command('inspect')
       }
     } else {
       console.log(`\n${bold('Console:')} ${muted('(clean)')}`);
+    }
+
+    // ── Transient console errors (seen on first probe, gone on re-probe) ──
+    if (transientErrors.length > 0) {
+      console.log(`\n${bold('Transient console errors')} ${muted(`(${transientErrors.length}, not reproduced on re-probe)`)}:`);
+      for (const line of transientErrors) {
+        console.log(muted(line));
+      }
+      console.log(muted('One-time cold-load artifact (first hit of freshly-deployed assets, or a cross-origin script) — not reproducible, not in your app code. Ignore unless it recurs.'));
     }
 
     // ── Failed Resources ──


### PR DESCRIPTION
## Problem

After deploying a tip-calculator app, an agent ran `gipity page inspect` to verify the page. Inspect reported **two console errors** with no message or stack — only a guessy hint string. Those errors were a **one-time cold-load transient**: the first hit of freshly-deployed assets threw a cross-origin "Script error." with no message/stack (details hidden by the browser's cross-origin policy), which the page's own `window.onerror` can't capture either. They were **not in the app and not reproducible** — re-running inspect (default wait, and `--wait 1500`) came back clean every time.

Because inspect flagged this self-generated noise as a real defect, the agent spent a large fraction of the run chasing a phantom: registering error handlers via `page eval`, pulling `failedResources` with `--json`/`--all` (empty), reading ~200 lines of the bundled SDK source to see whether the SDK itself was throwing, and finally re-running inspect four more times before concluding it was cold-load flake. A verification tool that cries wolf on its own first run is a real defect in the build→verify loop.

## Root cause & fix

The "cries wolf" behavior is the core platform defect: inspect made a **single** probe and reported whatever console errors that one probe saw, with no way for the agent to tell genuine errors from non-reproducible cold-load noise.

`page inspect` now **self-verifies console errors before flagging them** (`src/commands/page-inspect.ts`):

- If the first probe reports any error-level console line, inspect **re-probes once** (the sticky browser session is now warm / assets propagated) and keeps only the errors that **recur**.
- Errors seen on a single probe are surfaced separately under a **`Transient console errors (not reproduced on re-probe)`** section with a one-line note that they're a one-time cold-load artifact, not app code — and moved to a `transientConsole` field in `--json`.
- The re-probe runs only when errors are present (no added latency on clean pages), and falls back to reporting the first probe's console as-is if the re-probe itself fails.

This encodes the exact resolution method the agent had to perform by hand (re-run and check reproducibility) into the tool, and works regardless of *why* an error was transient or what the error text is — no brittle hint-string matching.

### Related (already fixed server-side, sibling repo)

The misleading hint text ("often a CSP violation or a failed ESM/module import…") is generated server-side and has **already been rewritten** in the platform repo (`server/src/services/browser-sandbox/console-parsers.ts`, `EMPTY_ERROR_HINT`) to correctly explain the cross-origin cause and note it "may show on only some probes." That sibling-repo fix can't be made from this CLI worktree; this CLI change makes inspect robust regardless of which hint the deployed server returns — transient errors are demoted before the hint is even shown.

## Tests

Added 3 tests to `src/__tests__/cli-cmd-page.test.ts`: a reproducible error is re-probed and still reported; a non-reproducible error is demoted to transient; `--json` moves it to `transientConsole`. Full `npm run test:smoke` passes except one pre-existing, unrelated failure (`CLI text-analysis mirror matches the shared canonical source`) that also fails on a clean tree.

## Scorecard

(no scorecard — human-filed or legacy issue)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)
