### PR TITLE
feat: `gipity page inspect/eval --wait` 30s hard cap (and terse cap error) blocks observing a slow auto-advancing app

### DIFF
--- a/src/__tests__/cli-cmd-page.test.ts
+++ b/src/__tests__/cli-cmd-page.test.ts
@@ -108,6 +108,40 @@ test('gipity page inspect omits fakeMedia when --fake-media is absent', async ()
   assert.equal((req!.body as { fakeMedia?: boolean }).fakeMedia, undefined);
 });
 
+test('gipity page inspect clamps --wait over the 30s cap and explains instead of leaking a raw server error', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/inspect', { body: { data: baseBundle } });
+  const r = await run(['page', 'inspect', 'https://example.com', '--wait', '60000']);
+  assert.equal(r.status, 0, r.stderr);
+  const req = mock.requests().find(q => q.url === '/tools/browser/inspect');
+  assert.equal((req!.body as { waitMs?: number }).waitMs, 30000, 'waitMs clamped to the cap');
+  assert.match(r.stderr, /30000ms cap/);
+  assert.match(r.stderr, /page test/);
+});
+
+test('gipity page inspect forwards a sub-cap --wait unchanged with no warning', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/inspect', { body: { data: baseBundle } });
+  const r = await run(['page', 'inspect', 'https://example.com', '--wait', '5000']);
+  assert.equal(r.status, 0, r.stderr);
+  const req = mock.requests().find(q => q.url === '/tools/browser/inspect');
+  assert.equal((req!.body as { waitMs?: number }).waitMs, 5000);
+  assert.doesNotMatch(r.stderr, /cap/);
+});
+
+test('gipity page eval clamps --wait over the 30s cap in the kickoff body', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/eval', { body: { data: { evalJobId: 'job-w', status: 'queued' } } });
+  mock.on('GET /tools/browser/eval/job-w', { body: { data: {
+    status: 'done', url: 'https://example.com', result: '1', truncated: false,
+  } } });
+  const r = await run(['page', 'eval', 'https://example.com', '1', '--wait', '90000']);
+  assert.equal(r.status, 0, r.stderr);
+  const req = mock.requests().find(q => q.url === '/tools/browser/eval');
+  assert.equal((req!.body as { waitMs?: number }).waitMs, 30000);
+  assert.match(r.stderr, /30000ms cap/);
+});
+
 test('gipity page inspect --json emits the raw inspect bundle', async () => {
   mock.reset();
   mock.on('POST /tools/browser/inspect', { body: { data: {

--- a/src/commands/page-eval.ts
+++ b/src/commands/page-eval.ts
@@ -18,6 +18,26 @@ type EvalJobRecord =
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+// A single browser session is held open synchronously for the whole --wait, so
+// the server caps it at the gateway idle timeout. Longer is impossible in one
+// shot; watching an app past 30s means several windows, not one big wait.
+export const MAX_WAIT_MS = 30_000;
+
+/** Parse --wait (defaulting to 500ms), clamping to the per-call cap. When the
+ *  caller asks for more than the cap, clamp and explain — to stderr, so --json
+ *  stdout stays clean — and point at the windowed watch primitive instead of
+ *  leaking the server's raw "Too big" validation error. */
+export function capWaitMs(rawWait: string, url: string): number {
+  const parsed = parseInt(rawWait, 10);
+  const wait = Number.isFinite(parsed) && parsed >= 0 ? parsed : 500;
+  if (wait <= MAX_WAIT_MS) return wait;
+  console.error(warning(
+    `--wait ${wait}ms exceeds the ${MAX_WAIT_MS}ms cap (one browser session is held open synchronously; longer trips the gateway timeout) — using ${MAX_WAIT_MS}ms. ` +
+    `To watch an app that keeps changing past 30s, cover the span with staggered windows in one command: gipity page test "${url}" --clients N --stagger S.`,
+  ));
+  return MAX_WAIT_MS;
+}
+
 /** Poll the async eval job until it finishes. Eval runs server-side as a
  *  short-lived job (so a long --wait can't trip the gateway idle timeout);
  *  we submit, then poll the result out of the job store. `expectedWorkMs` is
@@ -56,13 +76,12 @@ export const pageEvalCommand = new Command('eval')
   .description('Evaluate a JS expression in a real browser on a page (DOM, computed styles, element rects)')
   .argument('<url>', 'URL to load')
   .argument('<expr>', 'JavaScript expression to evaluate in page context (result is JSON-serialized)')
-  .option('--wait <ms>', 'Sleep this many ms after DOMContentLoaded before evaluating (lets late async work settle)', '500')
+  .option('--wait <ms>', 'Sleep this many ms after DOMContentLoaded before evaluating (lets late async work settle; max 30000)', '500')
   .option('--wait-for <selector>', 'Wait until this CSS selector appears before evaluating (deterministic; replaces --wait)')
   .option('--wait-timeout <ms>', 'Max ms to wait for --wait-for before giving up', '5000')
   .option('--json', 'Output as JSON')
   .action((url: string, expr: string, opts) => run('Page eval', async () => {
-    const parsedWait = parseInt(opts.wait, 10);
-    const waitMs = Number.isFinite(parsedWait) && parsedWait >= 0 ? parsedWait : 500;
+    const waitMs = capWaitMs(opts.wait, url);
     const parsedTimeout = parseInt(opts.waitTimeout, 10);
     const waitForTimeoutMs = Number.isFinite(parsedTimeout) && parsedTimeout >= 0 ? parsedTimeout : 5000;
 

--- a/src/commands/page-inspect.ts
+++ b/src/commands/page-inspect.ts
@@ -3,6 +3,7 @@ import { post } from '../api.js';
 import { formatSize } from '../utils.js';
 import { brand, bold, error as clrError, warning, muted, info } from '../colors.js';
 import { run } from '../helpers/index.js';
+import { capWaitMs } from './page-eval.js';
 
 interface DebugBundle {
   url: string;
@@ -45,7 +46,7 @@ function shortUrl(url: string, truncate = true, maxLen = 100): string {
 export const pageInspectCommand = new Command('inspect')
   .description('Inspect a web page (console, failed resources, timing, layout overflow)')
   .argument('<url>', 'URL to inspect')
-  .option('--wait <ms>', 'Sleep this many ms after DOMContentLoaded before capturing (lets late async/LCP work settle)', '500')
+  .option('--wait <ms>', 'Sleep this many ms after DOMContentLoaded before capturing (lets late async/LCP work settle; max 30000)', '500')
   .option('--wait-for <selector>', 'Wait until this CSS selector appears before capturing (deterministic; replaces --wait)')
   .option('--wait-timeout <ms>', 'Max ms to wait for --wait-for before giving up', '5000')
   .option('--json', 'Output as JSON')
@@ -62,8 +63,7 @@ export const pageInspectCommand = new Command('inspect')
       process.exit(1);
     }
     return run('Page inspect', async () => {
-    const parsedWait = parseInt(opts.wait, 10);
-    const waitMs = Number.isFinite(parsedWait) && parsedWait >= 0 ? parsedWait : 500;
+    const waitMs = capWaitMs(opts.wait, url);
     const parsedTimeout = parseInt(opts.waitTimeout, 10);
     const waitForTimeoutMs = Number.isFinite(parsedTimeout) && parsedTimeout >= 0 ? parsedTimeout : 5000;
     const truncate = opts.truncate !== false;


### PR DESCRIPTION
## Problem

An agent building a realtime app that auto-advances on a timer (bot turns, a 10s restart countdown) wanted a ~60s passive observation window to catch runtime errors across a full game. `gipity page inspect ... --wait 60000` was rejected outright with `Page inspect failed: Too big: expected number to be <=30000` — the raw server-side Zod validation error, leaked verbatim. The agent had to discover the 30s ceiling by trial, got no result back, and split its check into multiple short windowed runs by hand.

Two defects: (1) `--wait` over the cap hard-fails instead of returning a usable capture, and (2) the error states only the numeric bound — no explanation of the limit and no pointer to what to do for a longer watch.

## Root cause

`page inspect` and `page eval` parsed `--wait` and passed it straight to `/tools/browser/inspect` / `/tools/browser/eval`, letting the server's Zod `<=30000` bound reject the request and surface its raw message. (The 30s cap itself is a genuine server/gateway bound — one browser session is held open synchronously for the whole `--wait`, and longer trips the gateway idle timeout — so it can't be lifted from the CLI repo.) Meanwhile the sibling `page test` command already clamps its `--wait` to 30000 gracefully; inspect/eval just never owned the same validation.

## Fix (cli only)

Added a shared `capWaitMs(rawWait, url)` in `page-eval.ts` (the existing browser-helper hub that `page-test` already imports from) and routed both `page inspect` and `page eval` through it:

- Clamp `--wait` to the 30000ms cap and proceed, so the command returns a usable 30s capture instead of hard-failing.
- When clamping, warn to **stderr** (so `--json` stdout stays clean) explaining *why* the cap exists and pointing at the windowed-watch primitive: `gipity page test "<url>" --clients N --stagger S` — which batches the multiple windows the agent ran by hand into one command.
- Sub-cap values pass through unchanged with no warning.
- `--wait` help text on both commands now notes `max 30000`, matching `page test`.

No raw server validation error can leak from these commands anymore.

Added three tests (`cli-cmd-page.test.ts`) covering: inspect clamps over-cap `--wait` in the request body + emits the guidance, inspect forwards sub-cap `--wait` untouched with no warning, and eval clamps over-cap `--wait` in its kickoff body.

## Verification

`npm run build` clean; `npm test` passes (the one failing test, `CLI text-analysis mirror`, is a pre-existing environmental failure — it reads `../platform/...` which is absent in this isolated cli-only worktree, unrelated to this change).

## Scorecard

(no scorecard — human-filed or legacy issue)

## Related (not closed here — distinct root causes, mentioned for the sweep)

- #41 `page eval` terse `CDP command timed out: Runtime.evaluate` on long in-page awaits — separate mechanism (browser action timeout, not the `--wait` Zod cap).
- #42 `page screenshot` silently ignores `--wait` — missing option support, different fix.
- #36 `page test` 15s `--observe` hold cap — the `MAX_HOLD_MS` browser-action bound.

Notes: the `.ts` source files are the only change — no generated files or skill docs in this repo touch the cap.

Closes #30
🤖 Generated with [Claude Code](https://claude.com/claude-code)
