### PR TITLE
feat: No first-class path to functionally test interactive frontend code; agent hand-rolled a `window.*`-exposed harness driven via /tmp scripts + `page eval` command-substitution

### DIFF
--- a/src/__tests__/cli-cmd-page.test.ts
+++ b/src/__tests__/cli-cmd-page.test.ts
@@ -1,5 +1,7 @@
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { runCliAsync } from './helpers/spawn-cli.js';
 import { startMockServer, MockServer } from './helpers/mock-server.js';
 import { makeAuthedHome } from './helpers/test-home.js';
@@ -145,6 +147,45 @@ test('gipity page eval --json emits url, result, and truncated', async () => {
   const parsed = JSON.parse(r.stdout.trim());
   assert.equal(parsed.result, '42');
   assert.equal(parsed.truncated, true);
+});
+
+test('gipity page eval --file sends the script file contents as the expr', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/eval', { body: { data: { evalJobId: 'job-1', status: 'queued' } } });
+  mock.on('GET /tools/browser/eval/job-1', { body: { data: {
+    status: 'done', url: 'https://example.com', result: '{"ok":true}', truncated: false,
+  } } });
+  const scriptPath = join(home, 'draw-flow.js');
+  const script = '(function(){ return JSON.stringify({ ok: true }); })()';
+  writeFileSync(scriptPath, script);
+  const r = await run(['page', 'eval', 'https://example.com', '--file', scriptPath, '--json']);
+  assert.equal(r.status, 0, r.stderr);
+  const req = mock.requests().find((q) => q.url === '/tools/browser/eval');
+  assert.ok(req, 'eval request was received');
+  assert.equal((req!.body as { expr: string }).expr, script);
+});
+
+test('gipity page eval rejects passing both an inline expr and --file', async () => {
+  mock.reset();
+  const scriptPath = join(home, 'flow.js');
+  writeFileSync(scriptPath, 'document.title');
+  const r = await run(['page', 'eval', 'https://example.com', 'document.title', '--file', scriptPath]);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /either an inline <expr> arg or --file/);
+});
+
+test('gipity page eval requires an inline expr or --file', async () => {
+  mock.reset();
+  const r = await run(['page', 'eval', 'https://example.com']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /Provide an inline <expr> arg or --file/);
+});
+
+test('gipity page eval reports an unreadable --file path', async () => {
+  mock.reset();
+  const r = await run(['page', 'eval', 'https://example.com', '--file', join(home, 'does-not-exist.js')]);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /Cannot read file/);
 });
 
 test('gipity page eval surfaces a failed eval job', async () => {

--- a/src/commands/page-eval.ts
+++ b/src/commands/page-eval.ts
@@ -1,6 +1,7 @@
+import { readFileSync } from 'node:fs';
 import { Command } from 'commander';
 import { post, get, ApiError } from '../api.js';
-import { brand, bold, muted, warning } from '../colors.js';
+import { brand, bold, muted, warning, error as clrError } from '../colors.js';
 import { run } from '../helpers/index.js';
 
 export interface EvalResult {
@@ -52,15 +53,40 @@ export async function pollEvalResult(evalJobId: string, expectedWorkMs: number):
 // curated metrics don't cover what you need (computed styles, element rects,
 // visibility, z-index stacks), eval an expression in page context and get the
 // serialized result back. Runs in the same browser sandbox as inspect.
+//
+// The body runs as an async function, so it can be an inline expression OR a
+// multi-statement script with `return`/`await`. Pass a saved script with
+// --file to functionally exercise a page's own code paths headlessly (drive
+// tools, undo/redo, transforms) and `return` a JSON-serializable result —
+// no /tmp + shell command-substitution harness needed.
 export const pageEvalCommand = new Command('eval')
-  .description('Evaluate a JS expression in a real browser on a page (DOM, computed styles, element rects)')
+  .description('Evaluate JS in a real browser on a page (DOM, computed styles, element rects; inline expr or --file script)')
   .argument('<url>', 'URL to load')
-  .argument('<expr>', 'JavaScript expression to evaluate in page context (result is JSON-serialized)')
+  .argument('[expr]', 'JavaScript to evaluate in page context (inline expression or statement body with return/await; result is JSON-serialized). Omit when using --file.')
+  .option('--file <path>', 'Read the script body from a file instead of the inline <expr> arg (mutually exclusive). Runs as an async function body, so top-level return/await work.')
   .option('--wait <ms>', 'Sleep this many ms after DOMContentLoaded before evaluating (lets late async work settle)', '500')
   .option('--wait-for <selector>', 'Wait until this CSS selector appears before evaluating (deterministic; replaces --wait)')
   .option('--wait-timeout <ms>', 'Max ms to wait for --wait-for before giving up', '5000')
   .option('--json', 'Output as JSON')
-  .action((url: string, expr: string, opts) => run('Page eval', async () => {
+  .action((url: string, exprArg: string | undefined, opts) => run('Page eval', async () => {
+    if (exprArg !== undefined && opts.file) {
+      console.error(clrError('Pass either an inline <expr> arg or --file <path>, not both'));
+      process.exit(1);
+    }
+    if (exprArg === undefined && !opts.file) {
+      console.error(clrError('Provide an inline <expr> arg or --file <path>'));
+      process.exit(1);
+    }
+    let expr = exprArg as string;
+    if (opts.file) {
+      try {
+        expr = readFileSync(opts.file, 'utf8');
+      } catch {
+        console.error(clrError(`Cannot read file: ${opts.file}`));
+        process.exit(1);
+      }
+    }
+
     const parsedWait = parseInt(opts.wait, 10);
     const waitMs = Number.isFinite(parsedWait) && parsedWait >= 0 ? parsedWait : 500;
     const parsedTimeout = parseInt(opts.waitTimeout, 10);
@@ -82,7 +108,7 @@ export const pageEvalCommand = new Command('eval')
     if (d.navigationIncomplete) {
       console.log(`${warning('⚠ Navigation incomplete:')} ${d.note || 'page did not reach full load'}`);
     }
-    console.log(`${muted('Expression:')} ${expr}`);
+    console.log(opts.file ? `${muted('Script:')} ${opts.file}` : `${muted('Expression:')} ${expr}`);
     console.log(`\n${d.result || muted('(empty result)')}`);
     if (d.truncated) console.log(muted('\n(result truncated to fit context - narrow the expression for the full value)'));
   }));
@@ -93,6 +119,12 @@ export const pageEvalCommand = new Command('eval')
 // concurrent `page test --observe` instead, which overlaps N clients and reports
 // whether they actually ran together.
 pageEvalCommand.addHelpText('after', `
+Examples:
+  gipity page eval "https://dev.gipity.ai/me/app/" "document.title"
+  # Functionally test a page's own code paths: save a script that drives the UI
+  # and returns a JSON-serializable result, then run it (no /tmp + shell quoting):
+  gipity page eval "https://dev.gipity.ai/me/app/" --file ./tests/draw-flow.js --json
+
 Testing realtime/shared state across clients?
   Separate 'page eval' calls run sequentially (one finishes before the next
   starts), so they never overlap and will each see only themselves - a false


### PR DESCRIPTION
## Problem

There was no supported way to run a *saved* functional-test script against a single page headlessly. `gipity page eval` accepted only an inline `<expr>` argument — no `--file`, unlike the sibling `gipity sandbox run --file`. To verify that an interactive editor's tool code paths (draw, group/ungroup, undo/redo, cut, transform, reshape, text) actually worked, the agent had to write three test scripts to `/tmp` via heredocs and feed each one into `page eval` through shell command-substitution, because eval wouldn't load a file.

From the run:
- `gipity page eval --help` → confirmed no `--file` / script-file option.
- Agent fell back to `cat > /tmp/sdtest.js … ` + `gipity page eval <url> "$(cat /tmp/sdtest.js)"` for three separate scripts.

## Root-cause fix

Add `--file <path>` to `gipity page eval`, matching the existing `sandbox run --file` convention:

- `<expr>` is now optional; exactly one of `<expr>` or `--file` is required (clear errors otherwise).
- The eval body already executes as an async function server-side — `page test` routes statement bodies with `return`/`await` through the same `/tmp/browser/eval` `expr` field — so a saved multi-statement script Just Works as the body and can `return` a JSON-serializable result.
- Output prints the script path (not the whole body) when `--file` is used.
- Help text gains a functional-test example.

This removes the bespoke /tmp + command-substitution harness from the verification step: write `./tests/draw-flow.js`, run `gipity page eval <url> --file ./tests/draw-flow.js --json`.

The app-side `window.savidraw` test-hook exposure the agent did is a normal app design choice (a test seam to reach internal state) and isn't a platform defect, so it's left alone.

## Scope notes

- This is distinct from the realtime multi-client gap (#25) and post-interaction screenshot gap (#32), as the issue notes — not bundled.
- The `page eval` reference in the platform repo's `docs/skills/app-debugging.md` could mention `--file`; that's a sibling repo and can't be changed from this worktree.

## Tests

Added four cases to `cli-cmd-page.test.ts`: `--file` forwards file contents as `expr`; rejects `<expr>` + `--file` together; requires one of the two; reports an unreadable `--file` path. All 28 page tests pass.

## Scorecard

(no scorecard — human-filed or legacy issue)

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)