### PR TITLE
fix: `gipity page screenshot`/`eval` rough edges during verification: ENOENT on missing output dir + help-dump instead of a real error on first call

### DIFF
--- a/src/__tests__/cli-smoke.test.ts
+++ b/src/__tests__/cli-smoke.test.ts
@@ -87,6 +87,18 @@ describe('cli-smoke: error behavior', () => {
     assert.match(out, /Showing `gipity page screenshot --help`:/);
   });
 
+  it('the one-line error is the LAST line, after the help (survives `| tail`)', () => {
+    // Agents pipe CLI output through `| tail` to bound context; a leading error
+    // would be dropped, leaving only help that reads as success-with-no-result.
+    const r = runCli(['page', 'eval', 'http://a']);
+    const out = (r.stdout + r.stderr).replace(/\s+$/, '');
+    const lastLine = out.slice(out.lastIndexOf('\n') + 1);
+    assert.match(lastLine, /error: missing required argument 'expr'/);
+    // Help still renders inline (no second --help trip), including addHelpText.
+    assert.match(out, /Usage: gipity page eval/);
+    assert.match(out, /Testing realtime\/shared state/);
+  });
+
   it('status without auth prints not-logged-in message', () => {
     const r = runCli(['status']);
     // status returns 0 even when not logged in (it's a status report)

--- a/src/commands/page-screenshot.ts
+++ b/src/commands/page-screenshot.ts
@@ -1,6 +1,6 @@
 import { Command, Option } from 'commander';
 import { mkdirSync, writeFileSync } from 'fs';
-import { join, resolve as resolvePath } from 'path';
+import { dirname, join, resolve as resolvePath } from 'path';
 import { postForTarEntries } from '../api.js';
 import { getProjectRoot } from '../config.js';
 import { brand, bold, muted, success } from '../colors.js';
@@ -187,7 +187,6 @@ export const pageScreenshotCommand = new Command('screenshot')
     const slug = slugFromUrl(url);
     const ts = timestampSlug();
     const dir = defaultScreenshotDir();
-    if (!opts.output) mkdirSync(dir, { recursive: true });
     const savedFiles: string[] = [];
     for (let i = 0; i < pngs.length; i++) {
       const shot = meta.screenshots[i];
@@ -195,6 +194,10 @@ export const pageScreenshotCommand = new Command('screenshot')
       const target = opts.output
         ? opts.output
         : join(dir, defaultFilename(slug, ts, suffix));
+      // Create the target's parent dir so a `-o` path under a not-yet-existing
+      // directory (e.g. .gipity/screenshots/home.png) writes cleanly instead of
+      // failing with a raw ENOENT and forcing a manual `mkdir -p`.
+      mkdirSync(dirname(target), { recursive: true });
       writeFileSync(target, pngs[i].buffer);
       // Absolute path so the agent knows exactly where the file landed.
       savedFiles.push(resolvePath(target));

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,22 +199,33 @@ for (const cmd of HELP_SECTIONS.flatMap(s => s.cmds)) {
   program.addCommand(cmd);
 }
 
-// ── Malformed invocation → print the error AND the command's help inline ──
+// ── Malformed invocation → print the command's help inline, error LAST ──
 // When an agent guesses the wrong shape (excess args, unknown command/option,
-// missing arg), don't make it run `--help` as a second trip: Commander fires
-// error() on the offending (sub)command, so showHelpAfterError(true) appends
-// that exact command's help, and a labeled header names the canonical help
-// invocation. addCommand doesn't inherit these settings, so apply recursively.
+// missing arg), don't make it run `--help` as a second trip: render that exact
+// command's help inline. The one-line error goes LAST, not first: agents
+// routinely pipe CLI output through `| tail` to bound context, which would drop
+// a leading error and leave only the help — reading as success-with-no-result.
+// A trailing error survives `tail`, names exactly which argument was wrong, and
+// reads as the conclusive failure it is. addCommand doesn't inherit this, so
+// apply recursively. (We render help ourselves rather than via
+// showHelpAfterError so the error can come after it.)
 function fullCommandName(cmd: Command): string {
   const parts: string[] = [];
   for (let c: Command | null = cmd; c; c = c.parent) parts.unshift(c.name());
   return parts.join(' ');
 }
 function enableHelpAfterError(cmd: Command): void {
-  cmd.showHelpAfterError(true);
   cmd.configureOutput({
-    outputError: (str, write) =>
-      write(`${str.replace(/\n+$/, '')}\n\nShowing \`${fullCommandName(cmd)} --help\`:\n`),
+    // Commander calls this on the offending (sub)command. We render that exact
+    // command's full help (via outputHelp, so addHelpText blocks are included)
+    // FIRST, then write the one-line error LAST. Both go to the same writeErr
+    // stream synchronously, so the order holds. We do NOT call
+    // showHelpAfterError - that would render help a second time, before the error.
+    outputError: (str, write) => {
+      write(`Showing \`${fullCommandName(cmd)} --help\`:\n\n`);
+      cmd.outputHelp({ error: true });
+      write(`\n${str.replace(/\n+$/, '')}\n`);
+    },
   });
   for (const sub of cmd.commands) enableHelpAfterError(sub);
 }


### PR DESCRIPTION
## Problem

Two rough edges hit during the verification phase of a real run, both on `gipity page`:

**Problem 1 — ENOENT on a missing output dir.** `gipity page screenshot -o .gipity/screenshots/home-mobile.png` crashed with a raw `ENOENT: no such file or directory` when the output path's parent dir didn't exist. The agent had to insert a manual `mkdir -p .gipity/screenshots` turn and retry — a wasted verification cycle. `.gipity/` is the CLI's own state dir, so the agent reasonably assumed the tool managed paths under it.

**Problem 2 — bad args dump help that reads like success.** On the first call to both `screenshot` and `eval`, a malformed invocation (unknown option / wrong arg shape) printed the command's one-line error *above* a 20-30 line help block. Agents routinely pipe CLI output through `2>&1 | tail` to bound context (e.g. the #34 transcript), which **drops the leading error and keeps only the help** — so a hard failure reads as success-with-no-result, with no signal about *which* argument was wrong. Same `bad-args-silently-dump-help` pattern noted before on #32 (screenshot) and #34 (`test --filter`); it recurs across the whole `page` group.

## Root-cause fix

**Problem 1** — `src/commands/page-screenshot.ts`: create the target's parent directory (`mkdirSync(dirname(target), { recursive: true })`) before writing, for *both* the default `.gipity/screenshots/` path and an explicit `-o` path. Previously the `mkdir` only ran in the no-`-o` branch.

**Problem 2** — `src/index.ts` (`enableHelpAfterError`): render the offending command's help inline **first** (still no second `--help` trip; `addHelpText` blocks like eval's realtime guidance preserved) and write the one-line error **last**. The trailing error survives `| tail`, names the bad argument, and reads as the failure it is. Centralized in the recursive helper, so it covers the entire `page` group and every other command. Exit code stays non-zero.

A smoke test pins the new ordering (error is the last line; help still renders inline).

## Verification

- `npm run test:smoke` — 464/465 pass. The one failure (`cli-cmd-text` "mirror matches the shared canonical source") is pre-existing and environmental: it reads `platform/packages/shared/src/text-analysis.ts`, which isn't checked out in this single-repo worktree. Unrelated to this change.
- Manual: `page screenshot -o <new-dir>/x.png` no longer ENOENTs; `page eval`/`screenshot` with bad args end on a clear `error: ...` line that survives `| tail`.

## Related

- Partially addresses #32 (its help-dump-on-unknown-flag symptom is fixed platform-wide here); its separate feature ask — driving an interaction to capture *post-interaction* screenshot state — is **not** implemented, so #32 stays open.
- #34 (already closed) described the same help-dump pattern on `gipity test`; this is the general fix for it.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)