### PR TITLE
feat: accept the natural `gipity sandbox run <interpreter> <file>` shape and name the JS-default execution mode on failure

### DIFF
--- a/src/__tests__/cli-cmd-sandbox.test.ts
+++ b/src/__tests__/cli-cmd-sandbox.test.ts
@@ -75,6 +75,70 @@ test('gipity sandbox run --file reads the body and infers language from the exte
   assert.equal(posted?.language, 'python');
 });
 
+test('gipity sandbox run <interpreter> <file> shorthand reads the file and pins the language', async () => {
+  mock.reset();
+  let posted: { code: string; language: string } | undefined;
+  mock.on('POST /projects/p_TestProj/sandbox/execute', async (req) => {
+    posted = req.body as { code: string; language: string };
+    return { body: { data: { exitCode: 0, stdout: 'ok', stderr: '', durationMs: 10, timedOut: false } } };
+  });
+  const d = makeProjectDir({ apiBase: mock.apiBase });
+  writeFileSync(join(d, 'build_report.py'), 'print("from file")\n');
+  const r = await runCliAsync(['--api-base', mock.apiBase, 'sandbox', 'run', 'python', 'build_report.py'], { env: { HOME: home }, cwd: d });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(posted?.code, 'print("from file")\n');
+  assert.equal(posted?.language, 'python');
+});
+
+test('gipity sandbox run node <file> shorthand maps node to javascript', async () => {
+  mock.reset();
+  let posted: { language: string } | undefined;
+  mock.on('POST /projects/p_TestProj/sandbox/execute', async (req) => {
+    posted = req.body as { language: string };
+    return { body: { data: { exitCode: 0, stdout: 'ok', stderr: '', durationMs: 10, timedOut: false } } };
+  });
+  const d = makeProjectDir({ apiBase: mock.apiBase });
+  writeFileSync(join(d, 'app.js'), 'console.log(1)\n');
+  const r = await runCliAsync(['--api-base', mock.apiBase, 'sandbox', 'run', 'node', 'app.js'], { env: { HOME: home }, cwd: d });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(posted?.language, 'javascript');
+});
+
+test('gipity sandbox run <interpreter> <inline-code> pins the language for a non-file body', async () => {
+  mock.reset();
+  let posted: { code: string; language: string } | undefined;
+  mock.on('POST /projects/p_TestProj/sandbox/execute', async (req) => {
+    posted = req.body as { code: string; language: string };
+    return { body: { data: { exitCode: 0, stdout: 'hi', stderr: '', durationMs: 10, timedOut: false } } };
+  });
+  const r = await fresh(['sandbox', 'run', 'bash', 'echo hi']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(posted?.language, 'bash');
+  assert.equal(posted?.code, 'echo hi');
+});
+
+test('gipity sandbox run hints at the JS default when a shell snippet fails as JavaScript', async () => {
+  mock.reset();
+  mock.on('POST /projects/p_TestProj/sandbox/execute', { body: { data: {
+    exitCode: 1, stdout: '', stderr: "/work/_run.js:1\necho hi\n^^^^\nSyntaxError: Unexpected identifier 'hi'\n    at wrapSafe (node:internal/modules/cjs/loader:1464:18)",
+    durationMs: 10, timedOut: false,
+  } } });
+  const r = await fresh(['sandbox', 'run', 'echo hi; node --version']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /ran as JavaScript/);
+  assert.match(r.stderr, /--language bash/);
+});
+
+test('gipity sandbox run does NOT hint at the JS default when the language was explicit', async () => {
+  mock.reset();
+  mock.on('POST /projects/p_TestProj/sandbox/execute', { body: { data: {
+    exitCode: 1, stdout: '', stderr: 'SyntaxError: bad', durationMs: 10, timedOut: false,
+  } } });
+  const r = await fresh(['sandbox', 'run', '--language', 'bash', 'echo hi']);
+  assert.notEqual(r.status, 0);
+  assert.doesNotMatch(r.stderr, /ran as JavaScript/);
+});
+
 test('gipity sandbox run rejects passing both inline code and --file', async () => {
   mock.reset();
   const d = makeProjectDir({ apiBase: mock.apiBase });

--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync, statSync } from 'fs';
 import { dirname, extname, relative } from 'path';
 import { post } from '../api.js';
 import { resolveProjectContext, getConfigPath } from '../config.js';
@@ -12,6 +12,20 @@ const LANG_MAP: Record<string, string> = {
   javascript: 'javascript',
   py: 'python',
   python: 'python',
+  bash: 'bash',
+  sh: 'bash',
+};
+
+// Interpreter tokens accepted at the head of a `run <interpreter> <file>`
+// invocation (e.g. `gipity sandbox run python build_report.py`), mirroring how
+// you'd launch a script locally. Maps each token to the canonical language.
+const INTERPRETERS: Record<string, string> = {
+  python: 'python',
+  python3: 'python',
+  py: 'python',
+  node: 'javascript',
+  js: 'javascript',
+  javascript: 'javascript',
   bash: 'bash',
   sh: 'bash',
 };
@@ -31,7 +45,7 @@ export const sandboxCommand = new Command('sandbox')
   .description('Run code in a sandbox');
 
 sandboxCommand
-  .command('run [code]')
+  .command('run [args...]')
   .description('Run code')
   .option('--language <language>', 'Language: js, py, or bash', 'js')
   .option('--file <path>', 'Read the code body from a file instead of the inline <code> arg; --language is inferred from the extension when not given')
@@ -65,6 +79,8 @@ Examples:
 
   # Run a script file directly (language inferred from .py)
   $ gipity sandbox run --file build_report.py
+  $ gipity sandbox run python build_report.py   # same thing, interpreter shorthand
+  $ gipity sandbox run bash "echo hi; ffmpeg -version"   # inline, language pinned
 
   # Surgical: only these files are mirrored in
   $ gipity sandbox run --language bash \\
@@ -79,33 +95,62 @@ Pre-installed: Python (pandas, numpy, matplotlib, Pillow, scipy, bs4),
 CLI tools (ImageMagick, FFmpeg, webp/cwebp, optipng, jq, pandoc, exiftool,
 GCC/Rust).
 `)
-  .action((code: string | undefined, opts, command: Command) => run('Sandbox', async () => {
+  .action((args: string[] = [], opts, command: Command) => run('Sandbox', async () => {
     const { config } = await resolveProjectContext();
 
-    if (code !== undefined && opts.file) {
+    // Resolve the positional args into either inline code or a script-file path.
+    // `run <interpreter> <file>` (e.g. `run python build_report.py`) is the natural
+    // mental model, so accept it: a leading interpreter token + a path becomes
+    // --file with the language pinned by the interpreter. A single positional is
+    // inline code, same as before.
+    let inlineCode: string | undefined;
+    let filePath: string | undefined = opts.file;
+    let langFromInterp: string | undefined;
+    if (args.length >= 2 && INTERPRETERS[args[0].toLowerCase()] !== undefined) {
+      langFromInterp = INTERPRETERS[args[0].toLowerCase()];
+      const rest = args.slice(1).join(' ');
+      // `run python build_report.py` -> a script file; `run bash "echo hi"` -> inline code.
+      if (existsSync(rest) && statSync(rest).isFile()) filePath = rest;
+      else inlineCode = rest;
+    } else if (args.length === 1) {
+      inlineCode = args[0];
+    } else if (args.length > 1) {
+      console.error(clrError('Unrecognized invocation. Pass inline code as a single quoted arg, a script with --file <path>, or use the `run <python|node|bash> <file>` shorthand.'));
+      process.exit(1);
+    }
+
+    if (inlineCode !== undefined && filePath) {
       console.error(clrError('Pass either an inline <code> arg or --file <path>, not both'));
       process.exit(1);
     }
-    if (code === undefined && !opts.file) {
+    if (inlineCode === undefined && !filePath) {
       console.error(clrError('Provide an inline <code> arg or --file <path>'));
       process.exit(1);
     }
 
-    let source = code;
-    if (opts.file) {
+    let source = inlineCode;
+    if (filePath) {
       try {
-        source = readFileSync(opts.file, 'utf8');
+        source = readFileSync(filePath, 'utf8');
       } catch {
-        console.error(clrError(`Cannot read file: ${opts.file}`));
+        console.error(clrError(`Cannot read file: ${filePath}`));
         process.exit(1);
       }
     }
 
-    // Infer language from the file extension unless --language was given explicitly.
-    const fromExt = opts.file && command.getOptionValueSource('language') === 'default'
-      ? LANG_MAP[extname(opts.file).slice(1).toLowerCase()]
+    // Language precedence: interpreter token > file extension (unless --language
+    // was passed explicitly) > the --language value (default js).
+    const fromExt = filePath && !langFromInterp && command.getOptionValueSource('language') === 'default'
+      ? LANG_MAP[extname(filePath).slice(1).toLowerCase()]
       : undefined;
-    const language = fromExt || LANG_MAP[opts.language] || opts.language;
+    const language = langFromInterp || fromExt || LANG_MAP[opts.language] || opts.language;
+
+    // True when the run fell back to the implicit JS default - nothing in the
+    // command shape pinned a language. Used to explain the execution mode if a
+    // shell/Python snippet gets parsed as JavaScript and blows up (see hint below).
+    const usedDefaultJs = !langFromInterp
+      && command.getOptionValueSource('language') === 'default'
+      && language === 'javascript';
 
     if (!['javascript', 'python', 'bash'].includes(language)) {
       console.error(clrError(`Invalid language: ${opts.language}. Use: js, py, or bash`));
@@ -157,6 +202,14 @@ GCC/Rust).
         console.log(`\nOutput files ${pulledLocal ? 'synced to this directory' : 'saved to project'}:`);
         for (const f of res.data.outputFiles) console.log(`${f}`);
       }
-      if (res.data.exitCode !== 0) process.exit(res.data.exitCode);
+      if (res.data.exitCode !== 0) {
+        // A SyntaxError / CJS-loader trace under the implicit JS default almost
+        // always means the input was shell or Python that got run as JavaScript.
+        // The raw Node stack trace never says which mode ran, so name it.
+        if (usedDefaultJs && /SyntaxError|cjs\/loader|wrapSafe/.test(res.data.stderr || '')) {
+          console.error(dim('Hint: ran as JavaScript (the default). For a shell command pass `--language bash` (or `gipity sandbox run bash "<cmd>"`); for Python pass `--language py`.'));
+        }
+        process.exit(res.data.exitCode);
+      }
     }
   }));


### PR DESCRIPTION
## Problem

`gipity sandbox run` exposed a single positional `[code]` body plus `--language`/`--file`, so the natural mental models for running a script in the sandbox didn't work:

- **#29** — `gipity sandbox run python build_report.py` (treating `run` as `run <interpreter> <script>`, mirroring `python file.py`) failed with `too many arguments for 'run'. Expected 1 argument but got 2`. The agent recovered via `--file` after reading the help dump, but lost a turn.
- **#45** — A shell or Python snippet passed without `--language` ran as the implicit JS default and surfaced a bare Node CJS-loader stack trace (`at wrapSafe (node:internal/modules/cjs/loader…)`, `SyntaxError: Unexpected identifier 'hello'`). Nothing in the output named the execution mode, so the agent burned several probes figuring out the sandbox defaults to JavaScript.

Both are the same root issue: the `run` interface didn't match how you'd run code anywhere else, and never told you which language it used.

## Fix (platform, not docs)

`src/commands/sandbox.ts`:

- `run [code]` → `run [args...]`. A leading **interpreter token** (`python`/`python3`/`py`/`node`/`js`/`javascript`/`bash`/`sh`) is now accepted: the remainder is treated as a script **file** if it exists on disk, otherwise as **inline code**, with the language pinned by the interpreter. So `run python build_report.py`, `run node app.js`, and `run bash "echo hi; ffmpeg -version"` all work. A single positional is still inline code (unchanged); a multi-positional non-interpreter invocation gets a clear error instead of commander's generic arity message.
- On a non-zero exit where the run fell back to the **implicit JS default** and stderr looks like a wrong-language parse failure (`SyntaxError`/CJS-loader frames), print a one-line hint naming the mode and how to switch: *"ran as JavaScript (the default). For a shell command pass `--language bash`… for Python pass `--language py`."* This targets #45's exact signature and stays quiet for legitimate JS runtime failures and for explicitly-chosen languages.
- Help text gains two example lines for the shorthand.

Tests added to `src/__tests__/cli-cmd-sandbox.test.ts`: interpreter+file, `node`→javascript mapping, interpreter+inline-code, the JS-default hint firing on a SyntaxError trace, and the hint staying silent when `--language` was explicit. Full smoke suite passes (the one pre-existing failure, `CLI text-analysis mirror matches the shared canonical source`, fails identically on clean `origin/main` and is unrelated).

## Sibling-repo note

The issue's best-guess pointer also named `platform/docs/skills/sandbox-tools.md` (a different repo, not reachable from this `cli` worktree). No doc change is needed now — the CLI accepts the natural invocation, so there's no quirk left to document. The skill's existing `--language`/`--file` examples remain correct.

## Scorecard

#29: (no scorecard — human-filed/legacy issue)

#45:
```
success: false (db)
cost(usd-equiv): 20.0874  turns: 171
tokens: 371280 (14258 in / 357022 out)
tools: 93 total, 2 failed, retried: [Bash, Read, TaskCreate, TaskUpdate, Write, Edit]
timing: whole 2191.6s, in-tools ~2191.6s
```

Closes #29
Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)
