### PR TITLE
fix: Database-cap deploy failure dead-ends: `gipity db list` returns `[]` while the cap error says 100 exist, and there is no CLI path to list or reclaim databases counting toward the cap

### DIFF
--- a/src/__tests__/cli-cmd-db.test.ts
+++ b/src/__tests__/cli-cmd-db.test.ts
@@ -33,6 +33,14 @@ test('gipity db list (project-scoped) prints friendly names', async () => {
   assert.doesNotMatch(r.stdout, /undefined/);
 });
 
+test('gipity db list (project-scoped, empty) points at --all for the account cap', async () => {
+  mock.reset();
+  mock.on('GET /projects/p_TestProj/databases', { body: { data: [] } });
+  const r = await inProject(['db', 'list']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /gipity db list --all/);
+});
+
 test('gipity db list --all shows count/limit and groups by project', async () => {
   mock.reset();
   mock.on('GET /users/me/databases', { body: { data: {

--- a/src/__tests__/cli-cmd-deploy.test.ts
+++ b/src/__tests__/cli-cmd-deploy.test.ts
@@ -50,6 +50,23 @@ test('gipity deploy --json emits raw data', async () => {
   assert.equal(parsed.fileCount, 1);
 });
 
+test('gipity deploy database-cap failure points at db list --all / db drop', async () => {
+  mock.reset();
+  mock.on('POST /projects/p_TestProj/deploy', { body: { data: {
+    fileCount: 19, totalBytes: 1000, target: 'dev', elapsedMs: 500, batch: 1,
+    phases: [
+      { name: 'files', status: 'ok', summary: '19 files deployed' },
+      { name: 'database', status: 'failed', summary: 'Failed to create database: Maximum of 100 databases reached. Drop one first.' },
+      { name: 'functions', status: 'skipped', summary: 'previous phase failed' },
+    ],
+  } } });
+  const r = await fresh(['deploy', 'dev', '--no-sync']);
+  assert.equal(r.status, 1);
+  assert.match(r.stdout, /gipity db list --all/);
+  assert.match(r.stdout, /gipity db drop <name> --project <slug>/);
+  assert.match(r.stdout, /Deploy failed/);
+});
+
 test('gipity deploy fails when target is invalid', async () => {
   mock.reset();
   const r = await fresh(['deploy', 'staging', '--no-sync']);

--- a/src/commands/db.ts
+++ b/src/commands/db.ts
@@ -116,7 +116,10 @@ dbCommand
     } else {
       const config = requireConfig();
       const res = await get<{ data: DatabaseEntry[] }>(`/projects/${config.projectGuid}/databases`);
-      printList(res.data, opts, 'No databases. Create one: gipity db create <name>', db => db.friendlyName);
+      // This list is project-scoped; the account-wide database cap counts
+      // databases across ALL projects. An empty project can still be at the
+      // cap, so point at `--all` rather than implying nothing exists.
+      printList(res.data, opts, 'No databases in this project. Run `gipity db list --all` to see every database counting toward your account cap, or create one: gipity db create <name>', db => db.friendlyName);
     }
   }));
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -98,8 +98,20 @@ export const deployCommand = new Command('deploy')
 
       console.log(muted('─'.repeat(40)));
 
-      const hasFailed = d.phases?.some(p => p.status === 'failed');
-      if (hasFailed) {
+      const failedPhases = d.phases?.filter(p => p.status === 'failed') ?? [];
+      if (failedPhases.length > 0) {
+        // The database phase can fail on the account-wide database cap, whose
+        // server message ("Maximum of N databases reached. Drop one first.")
+        // names no command. The droppable databases live in OTHER projects, so
+        // the default project-scoped `gipity db list` shows nothing — point the
+        // caller straight at the account-wide list + drop path so they don't
+        // dead-end (or reach for raw DB access) to free a slot.
+        if (failedPhases.some(p => /databases? reached|database (cap|limit)/i.test(p.summary))) {
+          console.log('');
+          console.log(muted('Free a slot under the account database cap:'));
+          console.log(`  ${brand('gipity db list --all')}            ${muted('# every database counting toward the cap, by project')}`);
+          console.log(`  ${brand('gipity db drop <name> --project <slug>')} ${muted('# drop one from another project')}`);
+        }
         console.log(clrError(`Deploy failed`) + muted(` (${d.elapsedMs}ms)`));
         process.exit(1);
       } else {


### PR DESCRIPTION
## Problem

An agent hit the account-wide 100-database cap during `gipity deploy dev`. The database phase failed with `Maximum of 100 databases reached. Drop one first.` and functions were skipped — but:

1. The "Drop one first" instruction named no command.
2. `gipity db list` (default, project-scoped) returned `[]`, directly contradicting the cap, because the cap counts databases across **all** projects while bare `list` only shows the current (empty) one.
3. With no CLI path, the agent escalated to privileged infra — read the raw postgres connection string from `.mcp.json`, queried `information_schema.schemata`, cross-referenced 300+ project guids to find an orphan, and ran a manual `DROP SCHEMA ... CASCADE`. A normal user could do none of this.

## Root cause

The account-wide list/drop commands **already exist** (`gipity db list --all`, `gipity db drop <name> --project <slug>` → `/users/me/databases` + `/users/me/databases/drop`). The defect was purely **discoverability**: nothing connected the cap failure to those commands, and the only entry points the agent tried (the deploy error, bare `db list`) pointed nowhere or contradicted the cap.

## Fix (CLI-side, where the cap matters to the user)

The server returns a semantic error; the CLI is the right layer to translate it into CLI-specific next steps (the same server serves web/REST/agents, which shouldn't hardcode CLI syntax).

- **`deploy.ts`** — when a database phase fails on the cap (`/databases? reached|database (cap|limit)/i`), print the account-wide list + drop commands inline, right before `Deploy failed`. The droppable databases live in *other* projects, so this points straight at `--all`.
- **`db.ts`** — the empty project-scoped `db list` message now points at `gipity db list --all` instead of implying nothing exists, so the second entry point isn't a dead contradiction either.

Secondary nit observed in the issue (`gipity db --help` dumping 53.4KB) is the by-design `app-development` skill auto-append in `help-skills.ts` plus the harness persisting large output to a file — not part of this dead-end, and left as-is. The fix above removes the need to consult `db --help` at all by surfacing the exact commands at the point of failure.

## Tests

`npm run test:smoke` (compiled): added
- `gipity deploy database-cap failure points at db list --all / db drop`
- `gipity db list (project-scoped, empty) points at --all for the account cap`

Both pass; full `cli-cmd-deploy` (11) and `cli-cmd-db` (7) suites green.

## Scorecard

(no scorecard — human-filed or legacy issue)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)