### PR TITLE
feat: Verifying realtime cross-client overlap via `gipity page test` is awkward: 15s `--observe` hold cap + no way to run two different-role clients concurrently

### DIFF
--- a/src/__tests__/cli-cmd-page.test.ts
+++ b/src/__tests__/cli-cmd-page.test.ts
@@ -390,6 +390,63 @@ test('page test --observe surfaces a client action failure and exits non-zero', 
   assert.match(r.stdout, /action failed/);
 });
 
+test('page test --observe substitutes {{label}} into the URL so each client gets a distinct role', async () => {
+  mock.reset();
+  // The kickoff keys the job off the per-client URL (role=host vs role=join),
+  // proving one invocation launched two asymmetric roles concurrently.
+  mock.on('POST /tools/browser/eval', (req) => {
+    const url = String((req.body as { url?: string }).url ?? '');
+    return { body: { data: { evalJobId: url.includes('role=host') ? 'job-host' : 'job-join', status: 'queued' } } };
+  });
+  mock.on('GET /tools/browser/eval/job-host', evalDone({ label: 'host', startedAt: 1000, endedAt: 9000, samples: ['lobby', 'game'] }));
+  mock.on('GET /tools/browser/eval/job-join', evalDone({ label: 'join', startedAt: 2000, endedAt: 9000, samples: ['lobby', 'game'] }));
+  const r = await run([
+    'page', 'test', 'https://app.example/?role={{label}}',
+    '--clients', '2', '--labels', 'host,join', '--samples', '2',
+    '--observe', "document.querySelector('[data-screen]')?.dataset.screen",
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /overlapped for/);
+  const urls = mock.requests().filter((q) => q.url === '/tools/browser/eval').map((q) => (q.body as { url: string }).url);
+  assert.equal(urls.length, 2);
+  assert.ok(urls.includes('https://app.example/?role=host'), `expected a host URL, got ${urls.join(', ')}`);
+  assert.ok(urls.includes('https://app.example/?role=join'), `expected a join URL, got ${urls.join(', ')}`);
+});
+
+test('page test --observe warns to stderr when --hold exceeds the cap, keeping json stdout clean', async () => {
+  mock.reset();
+  mockInteractive({
+    Alice: { label: 'Alice', startedAt: 1000, endedAt: 9000, samples: [1, 2] },
+    Bob: { label: 'Bob', startedAt: 2000, endedAt: 9000, samples: [1, 2] },
+  });
+  const r = await run([
+    'page', 'test', 'https://app.example/',
+    '--clients', '2', '--labels', 'Alice,Bob', '--samples', '2', '--hold', '45000',
+    '--observe', "document.querySelectorAll('.present').length", '--json',
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stderr, /45000ms exceeds the 15000ms/);
+  // stdout stays parseable JSON despite the warning.
+  const out = JSON.parse(r.stdout.trim());
+  assert.equal(out.hold, 15000);
+});
+
+test('page test --observe warns on an unrecognized {{token}} instead of sending it literally', async () => {
+  mock.reset();
+  mockInteractive({
+    Alice: { label: 'Alice', startedAt: 1000, endedAt: 9000, samples: [1, 2] },
+    Bob: { label: 'Bob', startedAt: 2000, endedAt: 9000, samples: [1, 2] },
+  });
+  const r = await run([
+    'page', 'test', 'https://app.example/?name=Bot{{index}}',
+    '--clients', '2', '--labels', 'Alice,Bob', '--samples', '2',
+    '--observe', "document.querySelectorAll('.present').length",
+  ]);
+  assert.match(r.stderr, /Unrecognized placeholder/);
+  assert.match(r.stderr, /\{\{index\}\}/);
+  assert.match(r.stderr, /\{\{label\}\}/);
+});
+
 // ── screenshot default filename helpers (pure) ─────────────────────────────
 
 test('timestampSlug renders yyyy-mm-dd_hh-mm-ss, zero-padded, sortable', () => {

--- a/src/commands/page-test.ts
+++ b/src/commands/page-test.ts
@@ -149,11 +149,36 @@ function fmtSamples(samples: unknown[]): string {
 async function runInteractive(url: string, observe: string, opts: TestOpts): Promise<void> {
   const clients = Math.max(1, parseInt(opts.clients, 10) || 2);
   const stagger = opts.stagger != null ? Math.max(0, parseInt(opts.stagger, 10) || 0) : 0;
-  const hold = Math.min(MAX_HOLD_MS, Math.max(MIN_HOLD_MS, parseInt(opts.hold, 10) || 8000));
+  const rawHold = parseInt(opts.hold, 10) || 8000;
+  const hold = Math.min(MAX_HOLD_MS, Math.max(MIN_HOLD_MS, rawHold));
+  if (rawHold > MAX_HOLD_MS) {
+    // Surface the clamp (to stderr, so --json stdout stays clean) instead of
+    // leaving the agent to infer it from the printed "hold Nms" line.
+    console.error(warning(
+      `--hold ${rawHold}ms exceeds the ${MAX_HOLD_MS}ms per-client cap (each client samples inside one browser eval, bounded by the server's eval budget) — using ${MAX_HOLD_MS}ms. ` +
+      `Co-launch every role in this one command (put {{label}}/{{i}} in the URL) so all clients overlap for the whole window; a separately-started background client overlaps only the sliver of its window that lines up.`,
+    ));
+  }
   const samples = Math.min(30, Math.max(2, parseInt(opts.samples, 10) || 6));
   const settle = opts.waitFor ? 200 : 1000;
   const labels = (opts.labels ? String(opts.labels).split(',').map((s) => s.trim()) : []).filter(Boolean);
   const labelFor = (i: number) => labels[i] ?? `client-${i}`;
+
+  // Only {{label}} and {{i}} are substituted. Warn once on any other {{token}}
+  // (a natural guess like {{name}} or {{index}}) so it isn't sent literally to
+  // every client — the silent wrong-behavior trap of identical clients.
+  const unknown = new Set<string>();
+  for (const s of [url, opts.action ?? '', observe]) {
+    for (const m of s.matchAll(/\{\{\s*(\w+)\s*\}\}/g)) {
+      if (m[1] !== 'label' && m[1] !== 'i') unknown.add(`{{${m[1]}}}`);
+    }
+  }
+  if (unknown.size > 0) {
+    console.error(warning(
+      `Unrecognized placeholder(s) ${[...unknown].join(', ')} — only {{label}} and {{i}} are substituted per client; ` +
+      `anything else is sent literally to every client. Set per-client values with --labels and reference them as {{label}}.`,
+    ));
+  }
 
   if (!opts.json) {
     console.log(`${brand('Page test')} ${muted('(interactive)')} ${bold(url)}`);
@@ -165,6 +190,10 @@ async function runInteractive(url: string, observe: string, opts: TestOpts): Pro
     runs.push((async () => {
       await sleep(i * stagger * 1000);
       if (!opts.json) console.log(muted(`client ${i} (${labelFor(i)}) joining`));
+      // {{label}}/{{i}} substitute into the URL too, so one invocation can launch
+      // asymmetric roles concurrently (e.g. ?role={{label}} with --labels host,join)
+      // and the overlap check still confirms they coexisted.
+      const clientUrl = subst(url, labelFor(i), i);
       const expr = buildHarness(
         opts.action ? subst(opts.action, labelFor(i), i) : undefined,
         subst(observe, labelFor(i), i),
@@ -172,7 +201,7 @@ async function runInteractive(url: string, observe: string, opts: TestOpts): Pro
         hold,
         samples,
       );
-      return observeClient(url, expr, i, labelFor(i), settle, hold, opts.waitFor);
+      return observeClient(clientUrl, expr, i, labelFor(i), settle, hold, opts.waitFor);
     })());
   }
   const results = (await Promise.all(runs)).sort((a, b) => a.i - b.i);
@@ -296,7 +325,7 @@ async function runPassive(url: string, opts: TestOpts): Promise<void> {
 //  just because the clients never actually ran together.
 export const pageTestCommand = new Command('test')
   .description('Multi-client realtime check: load a URL in N concurrent headless clients; flag console errors, or drive an action and observe shared state (--observe)')
-  .argument('<url>', 'Deployed URL to load in every client')
+  .argument('<url>', 'Deployed URL to load in every client. In interactive mode (--observe), {{label}}/{{i}} substitute per client, so one invocation can give each client a distinct role (e.g. ?role={{label}} with --labels host,join).')
   .option('--clients <n>', 'Number of headless clients to launch', '2')
   .option('--stagger <s>', 'Seconds between client starts (passive default 12; interactive default 0)')
   .option('--wait <ms>', 'Passive mode: ms each client stays open after load (max 30000)', '24000')
@@ -318,7 +347,14 @@ Examples:
   gipity page test "https://dev.gipity.ai/me/app/" --clients 2 \\
     --action "document.querySelector('#name').value='{{label}}'; document.querySelector('form').requestSubmit();" \\
     --observe "document.querySelectorAll('.present').length" \\
-    --labels Alice,Bob`)
+    --labels Alice,Bob
+
+  # Asymmetric roles in ONE invocation: {{label}} in the URL routes client 0 to
+  # host and client 1 to join. They overlap in time (verified), so the joiner
+  # observes the live state the host is driving — no background-process dance.
+  gipity page test "https://dev.gipity.ai/me/app/?test-action={{label}}" --clients 2 \\
+    --labels host,join \\
+    --observe "document.querySelector('[data-screen]')?.dataset.screen"`)
   .action((url: string, opts: TestOpts) => run('Page test', async () => {
     if (opts.observe) {
       await runInteractive(url, opts.observe, opts);


### PR DESCRIPTION
## Problem

The agent built a host-authoritative multiplayer game and needed the routine realtime check: does a **joiner** client see the live state a separately-running **host** is driving? Interactive `gipity page test --observe` loads a **single URL in every client**, so there was no single-invocation way to launch a host-role client and a joiner-role client that overlap in time. The agent worked around it by backgrounding the host (`--hold 45000`), `sleep`-ing to let it advertise, then running the joiner in the foreground — twice. Compounding it:

- The joiner's `--observe` `--hold` was silently clamped to 15s with no feedback (the agent had to infer the cap from the printed `hold 15000ms`), shrinking the overlap window it had to *catch* the background host within.
- The first attempt false-negatived: the joiner landed in a stale lingering room from an earlier run and sat in the waiting screen.

Net: a one-line "does a joiner see the host's game" check became several deploy+rerun cycles plus manual process orchestration. The `app-realtime` skill doc even *prescribed* this — telling agents to run two separate, non-overlapping `page test` calls for asymmetric roles.

## Root-cause fix (`src/commands/page-test.ts`)

`{{label}}`/`{{i}}` were already substituted into `--action`/`--observe`, but not the URL. Now they substitute into the **URL** too, so **one invocation co-launches distinct roles**:

```
gipity page test "https://dev.gipity.ai/me/app/?test-action={{label}}" --clients 2 \
  --labels host,join \
  --observe "document.querySelector('[data-screen]')?.dataset.screen"
```

Client 0 → `?test-action=host`, client 1 → `?test-action=join`. They run genuinely concurrently and the **existing overlap verification** confirms they coexisted — so the joiner observes the live state the host is driving, with no background-process + `sleep` dance. Because the host is freshly started *alongside* the joiner, there's also no stale-lingering-room window to false-negative on.

Two supporting fixes:
- **Unrecognized `{{token}}` now warns** (to stderr) instead of being sent literally to every client. A natural guess like `?name=Bot{{i}}` now works (`{{i}}` is substituted); anything else (`{{index}}`, `{{name}}`) gets a one-line diagnostic instead of silently making every client identical.
- **The `--hold` clamp is now surfaced**: a `--hold` above the 15s per-client cap warns to stderr (keeping `--json` stdout clean) instead of silently shrinking the window. (The 15s cap itself is bounded by the server's per-eval exec budget in `siverson914/EasyClaw` `browser.ts` `execBudgetMs` — each client samples inside one async browser eval; with co-launched roles fully overlapping for the whole window, 15s is ample. A larger window would be a server-side budget change, noted below.)

## Also resolves part of #55

#55 bundles two problems. **Part 1** — "`page test` has no per-client URL parameterization; invented `{{i}}` passes through literally with no warning" — is the same root cause and is **fixed here** (URL substitution + the unknown-placeholder warning). **Part 2** (retrieving a finished `gipity test` run's detailed results without re-running the suite) is a different command (`gipity test`) and is **not** addressed; #55 stays open for it.

## Out of scope / follow-ups
- The `app-realtime` skill doc (`platform/docs/skills/app-realtime.md`, in the **EasyClaw** repo) still prescribes the old two-call asymmetric-role dance and should be updated to the single co-launch invocation above — can't be landed from this CLI worktree. The CLI's own `--help` already documents the new pattern.
- Raising the 15s `--hold` window further requires bumping the server eval exec budget (`EasyClaw` `browser.ts`).

## Tests
Added to `src/__tests__/cli-cmd-page.test.ts` (all 37 page tests pass):
- URL `{{label}}` substitution routes two clients to distinct `role=host`/`role=join` URLs in one invocation.
- `--hold` over the cap warns to stderr while `--json` stdout stays parseable (`hold: 15000`).
- An unrecognized `{{index}}` placeholder warns instead of passing through literally.

Two pre-existing smoke failures on `main` are unrelated to this change: the `text-analysis` mirror test needs `platform/` (absent in this isolated worktree), and a `cli-smoke` case still asserts the old `page eval` missing-arg error that #51 changed when it made `[expr]` optional.

## Scorecard
(no scorecard — human-filed or legacy issue)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)