### PR TITLE
fix: `gipity page eval` dies with a terse, unguided 'CDP command timed out: Runtime.evaluate' when an async eval body runs long internal waits

### DIFF
--- a/src/__tests__/cli-cmd-page.test.ts
+++ b/src/__tests__/cli-cmd-page.test.ts
@@ -281,6 +281,24 @@ test('gipity page eval surfaces a failed eval job', async () => {
   assert.match(r.stderr, /about:blank/);
 });
 
+// An eval body whose own awaits overrun the in-page execution budget comes back
+// from agent-browser as a {success:false, error:"CDP command timed out:
+// Runtime.evaluate"} envelope, surfaced verbatim as the result. The CLI must
+// translate that into an actionable error, not print the opaque envelope.
+test('gipity page eval translates the CDP execution-budget timeout into guidance', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/eval', { body: { data: { evalJobId: 'job-cdp', status: 'queued' } } });
+  mock.on('GET /tools/browser/eval/job-cdp', { body: { data: {
+    status: 'done', url: 'https://example.com', truncated: false,
+    result: '{"success":false,"data":null,"error":"CDP command timed out: Runtime.evaluate"}',
+  } } });
+  const r = await run(['page', 'eval', 'https://example.com', '(async()=>{})()']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /in-page execution budget/);
+  assert.match(r.stderr, /separate from --wait/);
+  assert.doesNotMatch(r.stderr, /CDP command timed out/);
+});
+
 // ── page test interactive mode (concurrent clients + overlap verification) ──
 // Each client posts to /tools/browser/eval (a harness that runs --action then
 // samples --observe) and polls the job. The mock keys off the per-client label

--- a/src/commands/page-eval.ts
+++ b/src/commands/page-eval.ts
@@ -69,6 +69,36 @@ export async function pollEvalResult(evalJobId: string, expectedWorkMs: number):
   throw new ApiError(504, 'EVAL_TIMEOUT', 'Eval did not finish in time; narrow the expression or lower --wait');
 }
 
+// The in-page execution budget for an eval body's OWN runtime (its `await`/
+// `setTimeout` pauses), enforced by agent-browser's per-command CDP timeout
+// (AGENT_BROWSER_DEFAULT_TIMEOUT) — distinct from --wait, which only sleeps
+// BEFORE the eval. Used to translate the opaque timeout envelope into guidance.
+const EVAL_EXEC_BUDGET_MS = 20_000;
+
+/** When the eval body's own runtime overruns the in-page execution budget,
+ *  agent-browser aborts the `Runtime.evaluate` CDP call and the failure comes
+ *  back as a `{success:false, error:"CDP command timed out: Runtime.evaluate"}`
+ *  envelope that the server surfaces verbatim as the eval `result` — opaque to
+ *  the caller (no timeout named, no distinction from the page or --wait). Detect
+ *  exactly that envelope and return an actionable message; null otherwise. */
+export function evalExecTimeoutMessage(result: string): string | null {
+  let parsed: { success?: unknown; error?: unknown };
+  try {
+    parsed = JSON.parse(result);
+  } catch {
+    return null;
+  }
+  if (!parsed || parsed.success !== false || typeof parsed.error !== 'string') return null;
+  if (!/CDP command timed out:\s*Runtime\.evaluate/i.test(parsed.error)) return null;
+  return (
+    `the expression hit the ~${EVAL_EXEC_BUDGET_MS / 1000}s in-page execution budget — the eval body ` +
+    `(including its own await/setTimeout pauses) ran longer than that. This budget is the time the ` +
+    `expression itself is allowed to run; it is separate from --wait, which only sleeps BEFORE the eval ` +
+    `and cannot extend it. Split a long interactive check into several shorter 'page eval' calls (e.g. ` +
+    `one per state to verify), keeping each body's in-page waits well under ${EVAL_EXEC_BUDGET_MS / 1000}s.`
+  );
+}
+
 // The long-tail escape hatch alongside `page inspect`'s fixed bundle: when the
 // curated metrics don't cover what you need (computed styles, element rects,
 // visibility, z-index stacks), eval an expression in page context and get the
@@ -118,6 +148,9 @@ export const pageEvalCommand = new Command('eval')
     });
     const d = await pollEvalResult(kickoff.data.evalJobId, waitMs);
 
+    const execTimeout = evalExecTimeoutMessage(d.result);
+    if (execTimeout) throw new Error(execTimeout);
+
     if (opts.json) {
       console.log(JSON.stringify(d));
       return;
@@ -143,6 +176,11 @@ Examples:
   # Functionally test a page's own code paths: save a script that drives the UI
   # and returns a JSON-serializable result, then run it (no /tmp + shell quoting):
   gipity page eval "https://dev.gipity.ai/me/app/" --file ./tests/draw-flow.js --json
+
+The eval body runs under a ~20s in-page execution budget (its own await/setTimeout
+pauses count; --wait only sleeps BEFORE the eval and does not extend it). For a long
+interactive sequence, split it into several shorter evals (one per state to verify)
+rather than one body with many long waits.
 
 Testing realtime/shared state across clients?
   Separate 'page eval' calls run sequentially (one finishes before the next


### PR DESCRIPTION
## Problem

`gipity page eval` running an async body with several in-body `await wait(...)` pauses returned `{"success":false,"data":null,"error":"CDP command timed out: Runtime.evaluate"}`. The error was opaque: it didn't say which timeout was hit, that it was the eval *execution* budget (distinct from the `--wait` sleep) rather than the page, or how long the budget is — and offered no path forward. The agent had to infer on its own that the in-body waits exceeded an internal cap and recover by splitting the single verification into separate, shorter `page eval` calls.

## Root cause

agent-browser caps each in-page eval at a ~20s CDP execution budget (`AGENT_BROWSER_DEFAULT_TIMEOUT`, set to `BROWSER_NAV_TIMEOUT_MS` = 20s on the browser container). When the eval body's own `await`/`setTimeout` pauses overrun it, agent-browser aborts the `Runtime.evaluate` CDP call and emits a `{success:false, data:null, error:"CDP command timed out: Runtime.evaluate"}` envelope. Server-side, `parseAgentBrowserEvalMeta` yields no `result`/`origin` for that envelope, so `runBrowserEval` falls back to surfacing the raw envelope chunk as the eval `result` of a `status:'done'` record. The CLI then prints it verbatim — a failure masquerading as a successful result, with no diagnosis.

## Fix (CLI)

In `page eval`, detect that exact timeout envelope in the returned result and translate it into an actionable error instead of printing it raw:
- Names the ~20s **in-page execution budget** and what counts against it (the body's own `await`/`setTimeout`).
- Distinguishes it from `--wait` (which only sleeps *before* the eval and cannot extend it).
- Points at the recovery the agent had to infer: split a long interactive check into several shorter `page eval` calls (one per state to verify).

Also adds a terse note to the command `--help` so the budget is discoverable up front. New unit test asserts the envelope is translated (not printed raw) and the call exits non-zero.

## Note on a deeper server-side fix (sibling repo)

The cleanest place to recognize this would be server-side, in `runBrowserEval` (`platform/server/src/routes/tools/browser.ts`) — it already special-cases other agent-browser failure envelopes and could turn the `{success:false, error:"CDP command timed out…"}` chunk into a proper `error` record rather than passing it through as a `result`. That can't be done from this `cli` worktree; flagging it here for a platform follow-up. The CLI translation fixes the agent-facing friction regardless.

## Scorecard

(no scorecard — human-filed or legacy issue)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)