### PR TITLE
fix: `gipity page screenshot` silently ignores `--wait` (valid on sibling page subcommands), wasting several verification cycles

### DIFF
--- a/src/__tests__/cli-cmd-page.test.ts
+++ b/src/__tests__/cli-cmd-page.test.ts
@@ -2,6 +2,7 @@ import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import * as tarPack from 'tar-stream';
 import { runCliAsync } from './helpers/spawn-cli.js';
 import { startMockServer, MockServer } from './helpers/mock-server.js';
 import { makeAuthedHome } from './helpers/test-home.js';
@@ -388,6 +389,61 @@ test('page test --observe surfaces a client action failure and exits non-zero', 
   ]);
   assert.notEqual(r.status, 0);
   assert.match(r.stdout, /action failed/);
+});
+
+// ── screenshot --wait / --post-load-delay (request-body) ───────────────────
+
+/** Pack a minimal screenshot tar (meta.json + one png) the CLI can parse. */
+function screenshotTar(): Promise<Buffer> {
+  const meta = {
+    full: false, finalUrl: 'https://example.com/', title: 'Example', status: 200, performance: null,
+    screenshots: [{
+      viewport: { width: 1280, height: 720, deviceScaleFactor: 1 },
+      width: 1280, height: 720, screenshotSizeBytes: 4, phase: 'initial-load',
+    }],
+  };
+  const pack = tarPack.pack();
+  const chunks: Buffer[] = [];
+  return new Promise((resolve) => {
+    pack.on('data', (c: Buffer) => chunks.push(c));
+    pack.on('end', () => resolve(Buffer.concat(chunks)));
+    pack.entry({ name: 'meta.json' }, JSON.stringify(meta));
+    pack.entry({ name: 'shot.png' }, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    pack.finalize();
+  });
+}
+
+async function mockScreenshot() {
+  const tar = await screenshotTar();
+  mock.on('POST /tools/browser/screenshot', { raw: tar, contentType: 'application/x-tar' });
+}
+
+test('gipity page screenshot honors --wait as an alias for --post-load-delay', async () => {
+  mock.reset();
+  await mockScreenshot();
+  const r = await run(['page', 'screenshot', 'https://example.com', '--wait', '6000', '-o', join(home, 'shot.png')]);
+  assert.equal(r.status, 0, r.stderr);
+  assert.doesNotMatch(r.stdout, /undefined/);
+  const req = mock.requests().find((q) => q.url === '/tools/browser/screenshot');
+  assert.equal((req!.body as { postLoadDelayMs?: number }).postLoadDelayMs, 6000, '--wait must reach the server, not be silently dropped');
+});
+
+test('gipity page screenshot lets the canonical --post-load-delay win over --wait', async () => {
+  mock.reset();
+  await mockScreenshot();
+  const r = await run(['page', 'screenshot', 'https://example.com', '--post-load-delay', '2000', '--wait', '6000', '-o', join(home, 'shot.png')]);
+  assert.equal(r.status, 0, r.stderr);
+  const req = mock.requests().find((q) => q.url === '/tools/browser/screenshot');
+  assert.equal((req!.body as { postLoadDelayMs?: number }).postLoadDelayMs, 2000);
+});
+
+test('gipity page screenshot defaults to 1000ms when neither delay flag is given', async () => {
+  mock.reset();
+  await mockScreenshot();
+  const r = await run(['page', 'screenshot', 'https://example.com', '-o', join(home, 'shot.png')]);
+  assert.equal(r.status, 0, r.stderr);
+  const req = mock.requests().find((q) => q.url === '/tools/browser/screenshot');
+  assert.equal((req!.body as { postLoadDelayMs?: number }).postLoadDelayMs, 1000);
 });
 
 // ── screenshot default filename helpers (pure) ─────────────────────────────

--- a/src/__tests__/helpers/mock-server.ts
+++ b/src/__tests__/helpers/mock-server.ts
@@ -14,10 +14,10 @@ import { AddressInfo } from 'net';
  */
 
 export type MockHandler =
-  | { status?: number; body?: unknown; raw?: string; contentType?: string }
+  | { status?: number; body?: unknown; raw?: string | Buffer; contentType?: string }
   | ((req: { method: string; url: string; body: unknown; headers: Record<string, string | string[] | undefined> }) =>
-      Promise<{ status?: number; body?: unknown; raw?: string; contentType?: string }> |
-      { status?: number; body?: unknown; raw?: string; contentType?: string });
+      Promise<{ status?: number; body?: unknown; raw?: string | Buffer; contentType?: string }> |
+      { status?: number; body?: unknown; raw?: string | Buffer; contentType?: string });
 
 export class MockServer {
   private routes = new Map<string, MockHandler>();

--- a/src/commands/page-screenshot.ts
+++ b/src/commands/page-screenshot.ts
@@ -130,7 +130,10 @@ function appendOption(value: string, previous: string[] = []): string[] {
 export const pageScreenshotCommand = new Command('screenshot')
   .description('Screenshot a web page')
   .argument('<url>', 'URL to screenshot')
-  .option('--post-load-delay <ms>', 'Delay after DOMContentLoaded before capture, in ms', '1000')
+  // No commander default: a default here makes opts.postLoadDelay always set,
+  // so the `?? opts.wait` merge below would never see the --wait alias. Default
+  // is applied in the merge instead.
+  .option('--post-load-delay <ms>', 'Delay after DOMContentLoaded before capture, in ms (default: 1000)')
   .option('--full', 'Capture the full scrollable page (default: viewport only)')
   .option('-o, --output <file>', 'Output path (single viewport only; default .gipity/screenshots/ss-<host>-<timestamp>.png)')
   .option('--device <names>', `Viewport preset(s): ${Object.keys(DEVICE_PRESETS).join(', ')} (comma-separated or repeat flag)`, appendOption, [] as string[])
@@ -144,7 +147,10 @@ export const pageScreenshotCommand = new Command('screenshot')
   // rather than reject it as an unknown option and send them on a --help detour.
   .addOption(new Option('--full-page', 'Alias for --full').hideHelp())
   .action((url: string, opts) => run('Page screenshot', async () => {
-    const delayRaw = opts.postLoadDelay ?? opts.wait;
+    // --wait is a hidden alias for --post-load-delay (agents reach for it because
+    // sibling `page inspect`/`eval` name the flag --wait). Canonical name wins if
+    // both given; fall back to the 1000ms default when neither is set.
+    const delayRaw = opts.postLoadDelay ?? opts.wait ?? '1000';
     const postLoadDelayMs = delayRaw !== undefined ? parseInt(String(delayRaw), 10) : undefined;
     if (postLoadDelayMs !== undefined && (!Number.isFinite(postLoadDelayMs) || postLoadDelayMs < 0)) {
       throw new Error('--post-load-delay must be a non-negative integer (ms)');


### PR DESCRIPTION
Problem
-------
`gipity page screenshot` accepted `--wait <ms>` and exited OK, but the flag had no effect. An agent verifying a 3D scene had just used `--wait` successfully on sibling `page eval`/`page inspect` (where it is the real flag), carried it over to `screenshot`, and the delay was silently dropped — so each shot looked like the scene "still had not rendered after a longer wait." The agent escalated the wait (6000 → 5000 → 9000ms), took four useless screenshots, and even did an intervening config-edit + redeploy chasing a non-bug, only discovering `--post-load-delay` via `--help`.

Root cause
----------
`page screenshot` *already* declared a hidden `--wait` alias for `--post-load-delay`, but it never worked. `--post-load-delay` carried a commander default of `1000`, so `opts.postLoadDelay` was always set and the `opts.postLoadDelay ?? opts.wait` merge could never reach `opts.wait`. The alias was dead code.

Fix
---
`src/commands/page-screenshot.ts`: drop the commander default and apply it in the merge instead — `opts.postLoadDelay ?? opts.wait ?? 1000`. Now:
- `--wait` (the natural cross-subcommand guess) actually takes effect;
- the canonical `--post-load-delay` still wins when both are given;
- the 1000ms default is preserved when neither is set (no behavior change in the no-flag case).

This addresses both facets the issue calls out: (a) the wrong-but-natural flag name now works, and (b) `--wait` is no longer accepted-then-silently-dropped — it is honored.

Distinct from cli#32 (unknown flag dumps help) and cli#35 (ENOENT/help-dump on first call): here no help dump occurred — the command ran normally and dropped the flag, the more deceptive mode.

Tests
-----
`src/__tests__/cli-cmd-page.test.ts`: three new request-body tests — `--wait` reaches the server as `postLoadDelayMs`, canonical `--post-load-delay` wins over `--wait`, and the 1000ms default holds when neither is set. `src/__tests__/helpers/mock-server.ts` extended to let a mock return a binary tar body (the screenshot endpoint returns a tar). Full `cli-cmd-page` suite passes (37/37).

Scorecard
---------
(no scorecard — human-filed or legacy issue)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)