### PR TITLE
feat: Multi-client/test verification gaps in the CLI: `page test` has no per-client URL parameterization (invented `{{i}}` placeholder passes through literally with no warning), and there is no discoverable way to fetch detailed results of a completed `gipity test` run without re-running the suite

### DIFF
--- a/src/__tests__/cli-cmd-page.test.ts
+++ b/src/__tests__/cli-cmd-page.test.ts
@@ -390,6 +390,37 @@ test('page test --observe surfaces a client action failure and exits non-zero', 
   assert.match(r.stdout, /action failed/);
 });
 
+// ── page test per-client URL substitution + unknown-token warning ──────────
+
+test('page test substitutes {{i}} in the URL so each client loads a distinct URL', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/inspect', { body: { data: baseBundle } });
+  const r = await run([
+    'page', 'test', 'https://app.example/?name=Bot{{i}}',
+    '--clients', '2', '--stagger', '0',
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+  const urls = mock.requests()
+    .filter((q) => q.url === '/tools/browser/inspect')
+    .map((q) => (q.body as { url: string }).url);
+  assert.ok(urls.includes('https://app.example/?name=Bot0'), urls.join(', '));
+  assert.ok(urls.includes('https://app.example/?name=Bot1'), urls.join(', '));
+  // The literal placeholder must NOT survive into any request.
+  assert.ok(!urls.some((u) => u.includes('{{i}}')));
+});
+
+test('page test warns when the URL carries an unrecognized {{...}} placeholder', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/inspect', { body: { data: baseBundle } });
+  const r = await run([
+    'page', 'test', 'https://app.example/?name=Bot{{name}}',
+    '--clients', '1', '--stagger', '0',
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /Unrecognized placeholder \{\{name\}\}/);
+  assert.match(r.stdout, /\{\{i\}\}/);
+});
+
 // ── screenshot default filename helpers (pure) ─────────────────────────────
 
 test('timestampSlug renders yyyy-mm-dd_hh-mm-ss, zero-padded, sortable', () => {

--- a/src/__tests__/cli-cmd-test.test.ts
+++ b/src/__tests__/cli-cmd-test.test.ts
@@ -36,6 +36,9 @@ test('gipity test --no-sync runs and prints pass/fail summary', async () => {
   assert.match(r.stdout, /3 passed/);
   assert.match(r.stdout, /health endpoint/);
   assert.doesNotMatch(r.stdout, /undefined/);
+  // The run prints a discoverable retrieval path so details can be re-fetched
+  // by GUID later without re-running the (possibly paid) suite.
+  assert.match(r.stdout, new RegExp(`gipity test status ${RUN_GUID} --json`));
 });
 
 test('gipity test --filter <path> runs tests for that path', async () => {
@@ -132,6 +135,26 @@ test('gipity test status <runGuid> shows current run state', async () => {
   assert.equal(r.status, 0, r.stderr);
   assert.match(r.stdout, /passed/);
   assert.match(r.stdout, /5\/5 passed/);
+});
+
+test('gipity test results <runGuid> --json re-fetches a finished run without re-running', async () => {
+  mock.reset();
+  mock.on(`GET /projects/p_TestProj/test/status/${RUN_GUID}`, { body: { data: {
+    runGuid: RUN_GUID, status: 'failed', total: 6, passed: 4, failed: 2, skipped: 0,
+    durationMs: 13467, totalFiles: 2, completedFiles: 2,
+    startedAt: '2026-05-01T10:00:00Z', updatedAt: '2026-05-01T10:00:01Z', finishedAt: '2026-05-01T10:00:01Z',
+    results: [
+      { path: 'api/gen.test.js', name: 'image gen', status: 'failed', durationMs: 9000, error: 'boom', retryCount: 0, isFlaky: false },
+    ],
+  } } });
+  // `results` is an alias for `status`; no /test/run POST should be issued.
+  const r = await fresh(['test', 'results', RUN_GUID, '--json']);
+  assert.equal(r.status, 0, r.stderr);
+  const parsed = JSON.parse(r.stdout.trim());
+  assert.equal(parsed.runGuid, RUN_GUID);
+  assert.equal(parsed.failed, 2);
+  assert.equal(parsed.results[0].error, 'boom');
+  assert.ok(!mock.requests().some((q) => q.url.endsWith('/test/run')), 'must not start a new run');
 });
 
 test('gipity test history shows recent runs', async () => {

--- a/src/commands/page-test.ts
+++ b/src/commands/page-test.ts
@@ -50,11 +50,33 @@ interface ObserveResult {
 const MAX_HOLD_MS = 15_000; // keep each in-page await under the ~20s browser action timeout
 const MIN_HOLD_MS = 1_000;
 
-/** Splice per-client values into a user expression. `{{label}}` → the client's
- *  label, `{{i}}` → its 0-based index. Plain string replace (no regex) so the
- *  expression's own characters are never treated as patterns. */
+/** Splice per-client values into a user string (URL, --action, or --observe).
+ *  `{{label}}` → the client's label, `{{i}}` → its 0-based index. Plain string
+ *  replace (no regex) so the string's own characters are never treated as
+ *  patterns. */
 function subst(expr: string, label: string, i: number): string {
   return expr.split('{{label}}').join(label).split('{{i}}').join(String(i));
+}
+
+/** Collect any `{{...}}` placeholders the runner does NOT recognize, so an
+ *  invented token (e.g. `{{name}}`) is flagged instead of passing through
+ *  verbatim into every client's URL/expression. */
+function unknownTokens(...strings: (string | undefined)[]): string[] {
+  const out = new Set<string>();
+  for (const s of strings) {
+    for (const m of (s ?? '').match(/\{\{[^}]*\}\}/g) ?? []) {
+      if (m !== '{{i}}' && m !== '{{label}}') out.add(m);
+    }
+  }
+  return [...out];
+}
+
+/** One-time warning (non-JSON) for unrecognized placeholders left as-is. */
+function warnUnknownTokens(unknown: string[], json?: boolean): void {
+  if (json || unknown.length === 0) return;
+  console.log(warning(
+    `⚠ Unrecognized placeholder ${unknown.join(', ')} left as-is — only {{i}} (0-based client index) and {{label}} are substituted per client.`,
+  ));
 }
 
 /** Build the statement-body script one client runs: do the one-time action,
@@ -155,6 +177,8 @@ async function runInteractive(url: string, observe: string, opts: TestOpts): Pro
   const labels = (opts.labels ? String(opts.labels).split(',').map((s) => s.trim()) : []).filter(Boolean);
   const labelFor = (i: number) => labels[i] ?? `client-${i}`;
 
+  warnUnknownTokens(unknownTokens(url, opts.action, observe), opts.json);
+
   if (!opts.json) {
     console.log(`${brand('Page test')} ${muted('(interactive)')} ${bold(url)}`);
     console.log(muted(`${clients} client(s), stagger ${stagger}s, hold ${hold}ms, ${samples} samples each`));
@@ -172,7 +196,7 @@ async function runInteractive(url: string, observe: string, opts: TestOpts): Pro
         hold,
         samples,
       );
-      return observeClient(url, expr, i, labelFor(i), settle, hold, opts.waitFor);
+      return observeClient(subst(url, labelFor(i), i), expr, i, labelFor(i), settle, hold, opts.waitFor);
     })());
   }
   const results = (await Promise.all(runs)).sort((a, b) => a.i - b.i);
@@ -235,6 +259,10 @@ async function runPassive(url: string, opts: TestOpts): Promise<void> {
   const clients = Math.max(1, parseInt(opts.clients, 10) || 2);
   const stagger = opts.stagger != null ? Math.max(0, parseInt(opts.stagger, 10) || 0) : 12;
   const wait = Math.min(30000, Math.max(2000, parseInt(opts.wait, 10) || 24000));
+  const labels = (opts.labels ? String(opts.labels).split(',').map((s) => s.trim()) : []).filter(Boolean);
+  const labelFor = (i: number) => labels[i] ?? `client-${i}`;
+
+  warnUnknownTokens(unknownTokens(url), opts.json);
 
   if (!opts.json) {
     console.log(`${brand('Page test')} ${bold(url)}`);
@@ -246,7 +274,7 @@ async function runPassive(url: string, opts: TestOpts): Promise<void> {
     runs.push((async () => {
       await sleep(i * stagger * 1000);
       if (!opts.json) console.log(`${muted(`client ${i}${i === 0 ? ' (first)' : ''} starting`)}`);
-      return inspectClient(url, wait, i);
+      return inspectClient(subst(url, labelFor(i), i), wait, i);
     })());
   }
   const results = (await Promise.all(runs)).sort((a, b) => a.i - b.i);
@@ -296,14 +324,14 @@ async function runPassive(url: string, opts: TestOpts): Promise<void> {
 //  just because the clients never actually ran together.
 export const pageTestCommand = new Command('test')
   .description('Multi-client realtime check: load a URL in N concurrent headless clients; flag console errors, or drive an action and observe shared state (--observe)')
-  .argument('<url>', 'Deployed URL to load in every client')
+  .argument('<url>', 'Deployed URL to load in every client ({{i}}=client index, {{label}}=client label are substituted per client, e.g. ?name=Bot{{i}})')
   .option('--clients <n>', 'Number of headless clients to launch', '2')
   .option('--stagger <s>', 'Seconds between client starts (passive default 12; interactive default 0)')
   .option('--wait <ms>', 'Passive mode: ms each client stays open after load (max 30000)', '24000')
   // Interactive mode (--observe drives it):
   .option('--observe <expr>', 'Interactive: JS expression sampled in each client to read shared state (e.g. presence count). Switches on interactive mode.')
   .option('--action <expr>', 'Interactive: one-time JS run in each client before observing (e.g. fill a name + submit). {{label}}/{{i}} are substituted per client.')
-  .option('--labels <csv>', 'Interactive: per-client labels substituted for {{label}} (default client-0, client-1, …)')
+  .option('--labels <csv>', 'Per-client labels substituted for {{label}} in the URL/--action/--observe (default client-0, client-1, …)')
   .option('--hold <ms>', `Interactive: total observe window per client (${MIN_HOLD_MS}-${MAX_HOLD_MS}ms)`, '8000')
   .option('--samples <k>', 'Interactive: number of observations across the hold window (2-30)', '6')
   .option('--wait-for <selector>', 'Interactive: wait for this CSS selector before running --action (deterministic readiness gate)')
@@ -312,6 +340,9 @@ export const pageTestCommand = new Command('test')
 Examples:
   # Passive: load in 3 staggered clients, flag console errors
   gipity page test "https://dev.gipity.ai/me/app/" --clients 3 --stagger 8
+
+  # Per-client URL params: each client joins under a distinct name (Bot0, Bot1, …)
+  gipity page test "https://dev.gipity.ai/me/app/?name=Bot{{i}}" --clients 2
 
   # Interactive: two concurrent clients each join with a name, then watch the
   # live presence count. The command confirms the clients actually overlapped.

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -208,6 +208,9 @@ export const testCommand = new Command('test')
       if (data.skipped > 0) parts.push(muted(`${data.skipped} skipped`));
       console.log(`${parts.join(', ')} ${muted(`(${data.durationMs}ms)`)}`);
 
+      // The run's results are stored; re-fetch them (no re-run) by GUID.
+      console.log(muted(`Re-fetch this run's details (no re-run): gipity test status ${runGuid} --json`));
+
       if (data.failed > 0) process.exit(1);
   }));
 
@@ -215,11 +218,16 @@ export const testCommand = new Command('test')
 
 testCommand
   .command('status')
-  .description('Check a test run')
+  .alias('results')
+  .description('Fetch a finished (or running) test run by GUID — full per-test results, no re-run')
   .argument('<runGuid>', 'Test run GUID (e.g. tr_abc123)')
   .option('--json', 'Output as JSON')
   .option('--follow', 'Follow until complete (poll)')
-  .action((runGuid: string, opts) => run('Status', async () => {
+  // optsWithGlobals: the parent `test` command also declares `--json`, and with
+  // root-level enablePositionalOptions commander attaches a post-subcommand
+  // `--json` to that parent — so the subcommand's own opts would miss it.
+  .action((runGuid: string, _o, command: Command) => run('Status', async () => {
+      const opts = command.optsWithGlobals();
       const config = requireConfig();
 
       if (opts.follow) {
@@ -263,7 +271,9 @@ testCommand
   .description('Show recent runs')
   .option('--limit <n>', 'Number of runs to show', '10')
   .option('--json', 'Output as JSON')
-  .action((opts) => run('History', async () => {
+  // optsWithGlobals: see the status subcommand — `--json` lands on the parent.
+  .action((_o, command: Command) => run('History', async () => {
+      const opts = command.optsWithGlobals();
       const config = requireConfig();
       const res = await get<{
         data: Array<{


### PR DESCRIPTION
## Problem

Two CLI verification gaps hit during a multi-client realtime run (issue #55):

**1. `gipity page test` had no per-client URL parameterization, and an unknown placeholder passed through silently.** To exercise a party flow the agent needed two headless clients joining the same URL under *different* names, and reasonably guessed a `{{i}}` per-client-index token: `?test-name=Bot{{i}}`. The runner already substituted `{{i}}`/`{{label}}` into `--action`/`--observe` — but **never into the URL** — so the literal string `Bot{{i}}` went out byte-for-byte identical to every client. Four players named literally `Bot{{i}}` piled into one game; the run "looked broken" and recovery took a `gipity db query` dig, a help-trawl, and app-side workarounds.

**2. Getting detailed results of a finished `gipity test` run required re-running the whole suite.** The completed run printed only `Run: tr_…` with no retrieval hint, and the agent's natural guess `gipity test results <id>` didn't exist. `gipity test --json` started a brand-new run (re-executing paid image/vision generations) just to see failure detail.

## Root-cause fix

**Problem 1 — `src/commands/page-test.ts`:**
- Substitute `{{i}}`/`{{label}}` into the **URL** per client in **both** passive and interactive modes (passive gained `--labels`/`labelFor` support to match).
- Added `unknownTokens()` + a one-time `⚠ Unrecognized placeholder …` warning so an invented token (e.g. `{{name}}`) is flagged instead of silently passing through.
- Documented URL substitution in the `<url>` arg help and added a passive example.

**Problem 2 — `src/commands/test.ts`:**
- The stored-results path (`gipity test status <runGuid>`) already existed but was undiscoverable and its `--json` was **silently swallowed**. Root cause: root-level `enablePositionalOptions()` + the parent `test` command also declaring `--json` made commander attach a post-subcommand `--json` to the **parent**, leaving the subcommand's own `opts.json` undefined. Fixed by reading `optsWithGlobals()` in the `status`/`history` actions (this also fixed `test history --json`, broken the same way).
- Added a `results` alias on the `status` subcommand (the shape agents guess) and a `Re-fetch this run's details (no re-run): gipity test status <guid> --json` hint after each run.

## Tests
- `page test` substitutes `{{i}}` into per-client URLs; warns on unrecognized `{{…}}`.
- `gipity test results <guid> --json` re-fetches a finished run without issuing a `/test/run` (no re-run); the run prints the retrieval hint.
- Full `npm run test:smoke` passes except two failures that pre-exist on clean `origin/main` in this isolated worktree (a text-analysis mirror test needing the sibling `platform/` repo, and an unrelated `page eval` smoke-test drift).

## Related repos
The `app-realtime` skill (in the `platform` repo, not editable from this worktree) documents `gipity page test`; it could optionally note URL `{{i}}` substitution, though it's now discoverable via `--help` and the warning.

## Scorecard
(no scorecard — human-filed or legacy issue)

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)
