### PR TITLE
fix: `gipity sync` reports a freshly-pulled job-written Storage file as 'Download missing', and the warning persists into the next deploy

### DIFF
--- a/src/__tests__/sync-apply.test.ts
+++ b/src/__tests__/sync-apply.test.ts
@@ -421,6 +421,57 @@ describe('sync() - fetch-intercepted', () => {
     assert.ok(completeCalls.length >= 1, 'at least one upload-complete for the conflict copy');
   });
 
+  it('downloads a Storage/job file listed with a leading slash; no "Download missing", and a re-sync is a noop', async () => {
+    // Repro: a job writes its output to Storage at `/uploads/fl_x/clip.mp4`. The
+    // tree listing returns that path WITH a leading slash, but the tar entry is
+    // slash-free (`uploads/fl_x/clip.mp4`) - matching the local fs key. Without
+    // normalization the bulk-tar lookup misses and sync reports "Download missing"
+    // for a file it just streamed, then re-plans it on every later run/deploy.
+    const { createHash } = await import('crypto');
+    const remoteSha = createHash('sha256').update('mp4-bytes').digest('hex');
+
+    let treeListCalls = 0;
+    const makeStub = () => stubFetch(async (url) => {
+      if (url.includes('/files/tree') && !url.includes('content=tar')) {
+        treeListCalls++;
+        return new Response(JSON.stringify({ data: [
+          { path: '/uploads/fl_x/clip.mp4', size: 9, modified: '2024', type: 'file',
+            guid: 'fl_x', contentHash: remoteSha, serverVersion: 4 },
+        ] }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url.includes('/files/tree?content=tar')) {
+        const tar = await import('tar-stream');
+        const pack = tar.pack();
+        pack.entry({ name: 'uploads/fl_x/clip.mp4' }, 'mp4-bytes');  // slash-free, like real tar
+        pack.finalize();
+        const chunks: Buffer[] = [];
+        for await (const c of pack as any) chunks.push(c);
+        return new Response(Buffer.concat(chunks), { status: 200 });
+      }
+      throw new Error(`unexpected: ${url}`);
+    });
+
+    const { clearConfigCache } = await import('../config.js');
+    clearConfigCache();
+    const { sync } = await import('../sync.js');
+
+    makeStub();
+    const result = await sync({ interactive: false });
+
+    assert.equal(result.errors.length, 0, `no errors, got: ${result.errors.join(', ')}`);
+    assert.equal(result.applied, 1);
+    assert.equal(readFileSync(join(projectDir, 'uploads', 'fl_x', 'clip.mp4'), 'utf-8'), 'mp4-bytes');
+
+    // The warning must not persist: the baseline now records the file, so a
+    // second sync sees it unchanged and plans nothing.
+    makeStub();
+    const again = await sync({ interactive: false });
+    assert.equal(again.errors.length, 0);
+    assert.equal(again.applied, 0);
+    assert.equal(again.plan.downloads, 0, 'no re-download on the next sync');
+    assert.ok(treeListCalls >= 2, 'both syncs hit the tree listing');
+  });
+
   it('apply-time 409 (baseline fresh but another client raced in between) → re-plans as conflict', async () => {
     // Plan sees: local='modified', remote='unchanged' → upload with CAS=baseline.
     // But server has already moved on between manifest-fetch and upload - returns

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -279,13 +279,25 @@ interface RemoteFileRaw {
   serverVersion: number;
 }
 
+// Tree paths key everything: the remote listing, the tar entries, the local
+// walk (which uses leading-slash-free `relative(root, …)`), and the baseline.
+// Source files come back slash-free, but Storage/job-written objects (e.g.
+// `/uploads/fl_…/clip.mp4`) are listed with a leading slash while their tar
+// entry is slash-free - so a blind `all.get('/uploads/…')` misses and sync
+// reports a freshly-pulled file as "Download missing", then re-plans it every
+// run. Strip leading slashes at every boundary so all four keys agree.
+function normalizeTreePath(p: string): string {
+  return p.replace(/^\/+/, '');
+}
+
 async function fetchRemote(projectGuid: string): Promise<Map<string, RemoteFileInfo>> {
   const res = await get<{ data: RemoteFileRaw[] }>(`/projects/${projectGuid}/files/tree`);
   const out = new Map<string, RemoteFileInfo>();
   for (const f of res.data) {
     if (f.type !== 'file') continue;
-    out.set(f.path, {
-      path: f.path,
+    const path = normalizeTreePath(f.path);
+    out.set(path, {
+      path,
       size: f.size,
       sha256: f.contentHash,
       serverVersion: f.serverVersion,
@@ -306,7 +318,7 @@ async function downloadAll(
     extract.on('entry', (header, entryStream, next) => {
       const chunks: Buffer[] = [];
       entryStream.on('data', (c: Buffer) => { chunks.push(c); onBytes?.(c.length); });
-      entryStream.on('end', () => { files.set(header.name, Buffer.concat(chunks)); next(); });
+      entryStream.on('end', () => { files.set(normalizeTreePath(header.name), Buffer.concat(chunks)); next(); });
       entryStream.resume();
     });
     extract.on('finish', () => resolve(files));
@@ -324,7 +336,7 @@ async function fetchOne(projectGuid: string, path: string): Promise<Buffer | nul
     return await new Promise<Buffer | null>((resolve, reject) => {
       let found: Buffer | null = null;
       extract.on('entry', (header, entryStream, next) => {
-        if (header.name === path) {
+        if (normalizeTreePath(header.name) === normalizeTreePath(path)) {
           const chunks: Buffer[] = [];
           entryStream.on('data', (c: Buffer) => chunks.push(c));
           entryStream.on('end', () => { found = Buffer.concat(chunks); next(); });


### PR DESCRIPTION
## Problem

A render job wrote its MP4 to Gipity Storage at `/uploads/fl_ve2xey45/gipnote.mp4`. When the agent ran `gipity sync` to pull it, a single invocation printed two contradictory lines about the same path:

```
↓ /uploads/fl_ve2xey45/gipnote.mp4 (6.8 MB)
1 action applied.
Download missing: /uploads/fl_ve2xey45/gipnote.mp4
```

The `Download missing` warning then leaked into the very next `gipity deploy dev`, prefixed `[sync]`, even though the path was never touched again. The agent gave up on sync and curled the public CDN URL instead.

## Root cause

Tree paths key everything: the `/files/tree` listing, the tar entries, the local walk (`relative(root, …)`, always slash-free), and the baseline. Source files come back slash-free, so they reconcile. But **Storage/job-written objects are listed WITH a leading slash** (`/uploads/…`) while their **tar entry is slash-free** (`uploads/…`).

So the bulk-tar lookup `all.get('/uploads/…')` missed → the `↓` line (from the plan) printed, then `Download missing` for the path it had *just streamed*. Because the download never completed, `applied` was never incremented for it and the **baseline was never written** — so every later `sync`/`deploy` re-planned the same doomed download and re-emitted the warning under `[sync]`. The leading `↑`/`1 action applied` came from the unrelated upload in the same plan.

## Fix

Normalize leading slashes off tree paths at every boundary — `fetchRemote` (listing), `downloadAll` (tar entries), and `fetchOne` — so the remote key, tar key, local fs key, and baseline key all agree. The Storage file now downloads cleanly, the baseline records it, and a re-sync is a noop. No more self-contradictory output and no leak into deploy.

`src/sync.ts` is the source change; `src/__tests__/sync-apply.test.ts` adds a regression test that mocks a leading-slash tree listing + slash-free tar entry. It reproduces the exact `Download missing: /uploads/fl_x/clip.mp4` failure on the unfixed code and asserts a clean download plus a noop re-sync. All sync/apply tests pass.

## Scorecard

(no scorecard — human-filed or legacy issue)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)