### PR TITLE
fix: `gipity page eval` silently returns null for a non-serializable/script-form result, with no diagnostic — agent had to guess and retry

### DIFF
--- a/src/__tests__/cli-cmd-page.test.ts
+++ b/src/__tests__/cli-cmd-page.test.ts
@@ -281,6 +281,63 @@ test('gipity page eval surfaces a failed eval job', async () => {
   assert.match(r.stderr, /about:blank/);
 });
 
+// A script that runs but returns undefined (no `return`) comes back as the raw
+// agent-browser envelope. The CLI must unwrap it to a clean value and explain
+// how to shape a returnable result instead of printing an opaque blob.
+test('gipity page eval explains a no-value (undefined) result and hides the raw envelope', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/eval', { body: { data: { evalJobId: 'job-nv', status: 'queued' } } });
+  mock.on('GET /tools/browser/eval/job-nv', { body: { data: {
+    status: 'done', url: 'https://example.com', truncated: false,
+    result: '{"success":true,"data":{"origin":"https://example.com","result":null},"error":null}',
+  } } });
+  const r = await run(['page', 'eval', 'https://example.com', "document.getElementById('x').value='hi'"]);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /no JSON-serializable value/);
+  assert.doesNotMatch(r.stdout, /"success":true/);  // raw envelope never shown
+});
+
+test('gipity page eval --json cleans the leaked envelope and attaches a hint', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/eval', { body: { data: { evalJobId: 'job-nvj', status: 'queued' } } });
+  mock.on('GET /tools/browser/eval/job-nvj', { body: { data: {
+    status: 'done', url: 'https://example.com', truncated: false,
+    result: '{"success":true,"data":{"origin":"https://example.com","result":null},"error":null}',
+  } } });
+  const r = await run(['page', 'eval', 'https://example.com', 'void 0', '--json']);
+  assert.equal(r.status, 0, r.stderr);
+  const parsed = JSON.parse(r.stdout.trim());
+  assert.equal(parsed.result, 'null');
+  assert.match(parsed.hint, /no JSON-serializable value/);
+});
+
+test('gipity page eval hints on a bare null result', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/eval', { body: { data: { evalJobId: 'job-null', status: 'queued' } } });
+  mock.on('GET /tools/browser/eval/job-null', { body: { data: {
+    status: 'done', url: 'https://example.com', result: 'null', truncated: false,
+  } } });
+  const r = await run(['page', 'eval', 'https://example.com', 'window.missing', '--json']);
+  assert.equal(r.status, 0, r.stderr);
+  const parsed = JSON.parse(r.stdout.trim());
+  assert.equal(parsed.result, 'null');
+  assert.match(parsed.hint, /no JSON-serializable value/);
+});
+
+// A genuine serialized value must pass through untouched — no spurious hint.
+test('gipity page eval does not hint on a real value', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/eval', { body: { data: { evalJobId: 'job-ok', status: 'queued' } } });
+  mock.on('GET /tools/browser/eval/job-ok', { body: { data: {
+    status: 'done', url: 'https://example.com', result: '{"n":1}', truncated: false,
+  } } });
+  const r = await run(['page', 'eval', 'https://example.com', '({n:1})', '--json']);
+  assert.equal(r.status, 0, r.stderr);
+  const parsed = JSON.parse(r.stdout.trim());
+  assert.equal(parsed.result, '{"n":1}');
+  assert.equal(parsed.hint, undefined);
+});
+
 // ── page test interactive mode (concurrent clients + overlap verification) ──
 // Each client posts to /tools/browser/eval (a harness that runs --action then
 // samples --observe) and polls the job. The mock keys off the per-client label

--- a/src/commands/page-eval.ts
+++ b/src/commands/page-eval.ts
@@ -12,6 +12,45 @@ export interface EvalResult {
   note?: string;
 }
 
+// Shown when an eval runs cleanly but returns nothing serializable. Turns a
+// bare/opaque `null` into a deterministic, actionable nudge so the agent shapes
+// a returnable value instead of guessing and retrying.
+export const EVAL_NO_VALUE_HINT =
+  'The eval ran but returned no JSON-serializable value. A statement body with no `return`, an assignment, a void call, or a DOM node/function all serialize to null. ' +
+  'End the script with an expression — or an explicit `return` — that yields plain data, e.g. `return { label: input.value, count: items.length }` or `return JSON.stringify(payload)`.';
+
+/** Normalize a raw eval result for display. The eval can come back as a useful
+ *  serialized value, the literal `null`/`undefined`/empty string, or — when the
+ *  script returns undefined — agent-browser's raw envelope leaking through
+ *  (`{"success":true,"data":{"origin":…,"result":null},"error":null}`). The last
+ *  two mean the same thing to the agent: no value came back. Unwrap the leaked
+ *  envelope so it never reaches the agent as an opaque blob, and flag the
+ *  no-value cases so the caller can attach EVAL_NO_VALUE_HINT. */
+export function normalizeEvalResult(raw: string): { result: string; noValue: boolean } {
+  const trimmed = (raw ?? '').trim();
+  if (trimmed === '' || trimmed === 'null' || trimmed === 'undefined') {
+    return { result: trimmed, noValue: true };
+  }
+  // A leaked agent-browser eval envelope (only emitted when the eval returns
+  // undefined): unwrap to the inner value. Strict shape match — exact key set
+  // plus a string origin — so a genuine user object never trips this.
+  if (trimmed.startsWith('{') && trimmed.includes('"result"')) {
+    try {
+      const env = JSON.parse(trimmed);
+      const isEnvelope = env && typeof env === 'object'
+        && Object.keys(env).every((k) => k === 'success' || k === 'data' || k === 'error')
+        && env.data && typeof env.data === 'object'
+        && typeof env.data.origin === 'string' && 'result' in env.data;
+      if (isEnvelope) {
+        const inner = env.data.result;
+        if (inner == null) return { result: 'null', noValue: true };
+        return { result: typeof inner === 'string' ? inner : JSON.stringify(inner), noValue: false };
+      }
+    } catch { /* not the envelope — fall through and show the raw value */ }
+  }
+  return { result: raw, noValue: false };
+}
+
 type EvalJobRecord =
   | { status: 'running' }
   | ({ status: 'done' } & EvalResult)
@@ -117,9 +156,10 @@ export const pageEvalCommand = new Command('eval')
       waitForTimeoutMs: opts.waitFor ? waitForTimeoutMs : undefined,
     });
     const d = await pollEvalResult(kickoff.data.evalJobId, waitMs);
+    const { result, noValue } = normalizeEvalResult(d.result);
 
     if (opts.json) {
-      console.log(JSON.stringify(d));
+      console.log(JSON.stringify(noValue ? { ...d, result, hint: EVAL_NO_VALUE_HINT } : { ...d, result }));
       return;
     }
 
@@ -128,7 +168,8 @@ export const pageEvalCommand = new Command('eval')
       console.log(`${warning('⚠ Navigation incomplete:')} ${d.note || 'page did not reach full load'}`);
     }
     console.log(opts.file ? `${muted('Script:')} ${opts.file}` : `${muted('Expression:')} ${expr}`);
-    console.log(`\n${d.result || muted('(empty result)')}`);
+    console.log(`\n${result.trim() ? result : muted('(empty result)')}`);
+    if (noValue) console.log(muted(`\n${EVAL_NO_VALUE_HINT}`));
     if (d.truncated) console.log(muted('\n(result truncated to fit context - narrow the expression for the full value)'));
   }));
 


### PR DESCRIPTION
## Problem

The agent deployed a countdown app and moved to functional verification via `gipity page eval`. Its first eval — a multi-statement script that filled form inputs, submitted, and read back DOM state — ran without error but came back as an unexplained `null`. The agent had to hypothesize ("likely a serialization quirk") and re-issue the same logic restructured as an async IIFE returning a `JSON.stringify`'d string. One wasted round-trip here; compounds in larger verification loops.

This is distinct from the previously-fixed statement-body rejection (cli #19 / platform #136) and the return/IIFE doc note (#122): here the script was **accepted and ran** — the *result* came back as a silent null.

## Root cause

Reproduced against a live app. When an eval body returns `undefined` (e.g. a statement script with no `return`), the server's last-ditch fallback dumps agent-browser's **raw envelope** through to the result:

```
{"success":true,"data":{"origin":"https://…","result":null},"error":null}
```

The CLI printed that blob verbatim. The agent saw `"result":null` buried in it and concluded "returned null" with no idea what was dropped or how to fix it. Observed result shapes:

| Eval | `result` returned to CLI |
|------|--------------------------|
| `document.title` | `"monitor"` (clean) |
| `({n:1})` | `"{\"n\":1}"` (clean) |
| explicit `null` | `"null"` |
| **`…; void 0` (no return)** | **`{"success":true,"data":{…,"result":null},"error":null}` (leaked envelope)** |

## Fix (CLI)

`src/commands/page-eval.ts` — normalize the eval result before display:
- **Unwrap the leaked agent-browser envelope** (strict shape match: exact `success`/`data`/`error` key set + string `data.origin`) so it never reaches the agent as an opaque blob — a genuine user object can't trip it.
- **Flag no-value results** (empty / `null` / `undefined` / leaked-null) with one actionable hint: *the eval returned no JSON-serializable value; end with an expression or explicit `return` that yields plain data, e.g. `return JSON.stringify(payload)`.*
- Applies to both human output and `--json` (adds a `hint` field). A genuine serialized value passes through untouched — no spurious hint.

Turns a guess-and-retry cycle into a deterministic, self-explaining outcome.

### Note on the sibling repo

The underlying *envelope leak* originates server-side (`platform` `server/src/routes/tools/browser.ts`, the `runWrappedEval` last-ditch `result = evalChunk.trim()` when the eval value is null). That can't ship from this `cli` worktree; the CLI now degrades that case gracefully regardless. Worth a follow-up in `platform` to emit a clean null + note at the source.

## Tests

`src/__tests__/cli-cmd-page.test.ts` — 4 new cases: envelope unwrap + hint (human), `--json` clean result + `hint` field, bare-`null` hint, and a no-hint regression guard for real values. Full `page` suite passes (38/38). The one unrelated smoke failure (`cli-cmd-text` mirror) is pre-existing — it reads `../platform/...` which doesn't exist in this isolated worktree.

## Scorecard

(no scorecard — human-filed or legacy issue)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)
