### PR TITLE
feat(browser): give the headless browser a real camera; verify vision apps for real

### DIFF
--- a/src/__tests__/cli-cmd-page.test.ts
+++ b/src/__tests__/cli-cmd-page.test.ts
@@ -1222,3 +1222,35 @@ test('gipity page screenshot says nothing about --action when it ran clean', asy
   assert.equal(r.status, 0, r.stderr);
   assert.doesNotMatch(r.stdout, /--action failed/);
 });
+
+// ── --camera: a real webcam feed for vision apps ────────────────────────────
+// A headless browser has no webcam, so without this a camera app's getUserMedia
+// rejects and the app's whole pipeline (frames → model → app logic) never runs —
+// which is what pushes agents into stubbing the model and exporting internals
+// just to test around the missing device. A wrong file type must fail locally,
+// before an upload and a browser launch, and must name what IS accepted.
+test('gipity page eval --camera rejects a non-media file locally, naming the accepted types', async () => {
+  mock.reset();
+  const bad = join(home, 'notes.txt');
+  writeFileSync(bad, 'not a frame');
+  const r = await run(['page', 'eval', 'https://example.com', '--camera', bad, 'document.title']);
+  assert.notEqual(r.status, 0);
+  const out = r.stderr + r.stdout;
+  assert.match(out, /unsupported file type/);
+  assert.match(out, /\.png/);
+  assert.match(out, /\.mp4/);
+  // Points at the in-platform way to produce a frame rather than leaving the
+  // caller to find one.
+  assert.match(out, /gipity generate image/);
+  // Nothing was uploaded — the validation is local.
+  assert.equal(mock.requests().filter((q) => q.url.includes('/uploads/')).length, 0);
+});
+
+test('gipity page screenshot --camera rejects a non-media file locally', async () => {
+  mock.reset();
+  const bad = join(home, 'notes2.txt');
+  writeFileSync(bad, 'not a frame');
+  const r = await run(['page', 'screenshot', 'https://example.com', '--camera', bad]);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr + r.stdout, /unsupported file type/);
+});

--- a/src/commands/page-eval.ts
+++ b/src/commands/page-eval.ts
@@ -5,7 +5,7 @@ import { brand, bold, muted, warning, success } from '../colors.js';
 import { run } from '../helpers/index.js';
 import { getAuth } from '../auth.js';
 import { resolveProjectContext } from '../config.js';
-import { uploadPublicFixture, deleteFixture, HostedFixture } from '../page-fixtures.js';
+import { uploadPublicFixture, uploadCameraFeed, assertCameraFile, deleteFixture, HostedFixture } from '../page-fixtures.js';
 
 export interface EvalResult {
   url: string;
@@ -205,6 +205,11 @@ export const pageEvalCommand = new Command('eval')
     'After the first eval, reload the page IN PLACE (localStorage/sessionStorage/cookies preserved) and evaluate this second expression against the post-reload DOM. One command verifies persisted state survives a reload: seed/assert state with <expr>, then assert the restored UI here.',
   )
   .option('--reload-file <path>', 'Read the post-reload expression from a file instead of inline --reload (mutually exclusive)')
+  .option(
+    '--camera <path>',
+    'Play a local image or video (.png/.jpg/.webp/.mp4/.webm/.y4m/.mjpeg) as the browser\'s WEBCAM feed, so a camera app\'s real pipeline (getUserMedia → MediaPipe/YOLOX → your app logic) runs headlessly on frames you choose. A still image loops as a one-frame feed. Implies --fake-media. No frame handy? gipity generate image "a hand making a closed fist, palm to camera".',
+  )
+  .option('--fake-media', 'Grant a synthetic microphone + camera and auto-accept the getUserMedia prompt, so a voice/camera app runs headlessly instead of hitting its no-camera path. The feed is a built-in test pattern (and a tone) — nothing a vision model can recognize; to drive a vision app use --camera <path> instead.')
   .option('--wait <ms>', 'Sleep this many ms after DOMContentLoaded before evaluating (lets late async work settle; max 30000)', '500')
   .option('--wait-for <selector>', 'Wait until this CSS selector appears before evaluating (deterministic; replaces --wait)')
   .option('--wait-timeout <ms>', 'Max ms to wait for --wait-for before giving up', '5000')
@@ -275,12 +280,26 @@ export const pageEvalCommand = new Command('eval')
     // exprs (wrapped in `return (...)`) and --file scripts. Cleanup in `finally`.
     const fixturePaths: string[] = opts.fixture ?? [];
     const hosted: HostedFixture[] = [];
+    // The webcam feed is hosted like a fixture but is NOT exposed to the eval
+    // body as `fixtures`/`fixtureUrl` — the page never fetches it; the browser
+    // plays it as the camera device. Tracked separately so it still gets
+    // cleaned up, without shifting the fixture map the caller indexes into.
+    let camera: HostedFixture | undefined;
     let projectGuid: string | undefined;
     let sentExpr = expr;
+    // Validate the camera file locally first: a wrong file type should cost one
+    // instant error, not an upload plus an opaque browser-side failure.
+    if (opts.camera) assertCameraFile(opts.camera);
     try {
-      if (fixturePaths.length) {
+      if (fixturePaths.length || opts.camera) {
         const { config } = await resolveProjectContext({});
         projectGuid = config.projectGuid;
+      }
+      if (opts.camera) {
+        console.log(muted(`Hosting camera feed ${opts.camera}…`));
+        camera = await uploadCameraFeed(projectGuid!, opts.camera);
+      }
+      if (fixturePaths.length) {
         for (const p of fixturePaths) {
           console.log(muted(`Hosting fixture ${p}…`));
           hosted.push(await uploadPublicFixture(projectGuid!, p));
@@ -297,6 +316,10 @@ export const pageEvalCommand = new Command('eval')
         waitForSelector: opts.waitFor || undefined,
         waitForTimeoutMs: opts.waitFor ? waitForTimeoutMs : undefined,
         auth: opts.auth || undefined,
+        // A camera feed needs the synthetic devices in place to be played into,
+        // so --camera implies --fake-media rather than failing on the pairing.
+        fakeMedia: opts.fakeMedia || !!camera || undefined,
+        cameraUrl: camera?.url,
       });
       // The reload leg re-runs the settle before its eval — budget for both.
       const d = await pollEvalResult(kickoff.data.evalJobId, reloadExpr !== undefined ? waitMs * 2 : waitMs);
@@ -337,6 +360,7 @@ export const pageEvalCommand = new Command('eval')
           ? `${muted('Auth:')} ${success('session established')}${who ? muted(` as ${who}`) : ''} ${muted('(what the page renders with it is app-defined)')}`
           : `${warning('Auth: session NOT established')}${d.auth.detail ? ` — ${d.auth.detail}` : ''} ${muted('(this is the anonymous view)')}`);
       }
+      if (camera) console.log(`${muted('Camera:')} ${camera.name} ${muted('(played as the webcam feed; getUserMedia resolves)')}`);
       if (hosted.length) console.log(`${muted('Fixtures:')} ${hosted.map((h) => h.name).join(', ')}`);
       console.log(opts.file ? `${muted('Script:')} ${opts.file}` : `${muted('Expression:')} ${summarizeExpr(expr)}`);
       console.log(`\n${result.trim() ? result : muted('(empty result)')}`);
@@ -349,7 +373,7 @@ export const pageEvalCommand = new Command('eval')
         if (d.reloadTruncated) console.log(muted('(reload result truncated to fit context - narrow the expression for the full value)'));
       }
     } finally {
-      for (const h of hosted) {
+      for (const h of [...hosted, ...(camera ? [camera] : [])]) {
         try {
           await deleteFixture(projectGuid!, h.guid);
         } catch (err) {
@@ -384,6 +408,13 @@ Examples:
   gipity page eval "https://dev.gipity.ai/me/app/" \\
     "localStorage.setItem('todo','milk'); document.title" \\
     --reload "({ restored: localStorage.getItem('todo'), heading: document.querySelector('h1')?.textContent })"
+
+  # Camera app (MediaPipe / YOLOX / any getUserMedia app): play a real image as
+  # the webcam so the app's OWN pipeline runs on a frame you control — no need to
+  # stub the model or export internals just to test around a missing camera.
+  gipity generate image "a hand making a closed fist, palm to camera, plain background" -o fist.png
+  gipity page eval "https://dev.gipity.ai/me/app/" --camera fist.png --wait 4000 \\
+    "document.querySelector('#detected-gesture').textContent"
 
 Module resolution: dynamic import() specifiers starting with ./ or ../ resolve
 against the PAGE URL, so import('./packages/i18n/index.js') loads the app's own

--- a/src/commands/page-screenshot.ts
+++ b/src/commands/page-screenshot.ts
@@ -8,6 +8,7 @@ import { brand, bold, muted, success, warning } from '../colors.js';
 import { formatSize } from '../utils.js';
 import { run } from '../helpers/index.js';
 import { withSpinner } from '../progress.js';
+import { uploadCameraFeed, assertCameraFile, deleteFixture, HostedFixture } from '../page-fixtures.js';
 
 type Viewport = { width: number; height: number; deviceScaleFactor?: number; device?: string };
 
@@ -213,7 +214,8 @@ export const pageScreenshotCommand = new Command('screenshot')
   .option('--device <names>', `Device preset(s): ${Object.keys(DEVICE_PRESETS).join(', ')} (comma-separated or repeat flag). mobile/tablet emulate a real touch device — touch events, mobile user-agent, DPR — so touch-gated mobile UI actually renders.`, appendOption, [] as string[])
   .option('--viewport <dims>', 'Raw viewport(s): WxH or WxH@dpr (comma-separated or repeat flag)', appendOption, [] as string[])
   .option('--no-reload-between', 'Skip reload between viewports (faster, lower fidelity - only safe for static pages)')
-  .option('--fake-media', 'Grant a synthetic microphone + camera and auto-accept the getUserMedia prompt, so voice/camera apps render headlessly (audio is a built-in tone, not real speech)')
+  .option('--fake-media', 'Grant a synthetic microphone + camera and auto-accept the getUserMedia prompt, so voice/camera apps render headlessly. The video feed is a built-in test pattern — to capture what the app does with a REAL frame (a hand, a face, an object), use --camera <path> instead.')
+  .option('--camera <path>', 'Play a local image or video (.png/.jpg/.webp/.mp4/.webm/.y4m/.mjpeg) as the browser\'s WEBCAM feed, then capture — so the shot shows the app reacting to a frame you chose (detected gesture, boxes, labels). Implies --fake-media.')
   .option('--auth', 'Capture the page signed in as you (your Gipity account), so UI behind a Sign-in-with-Gipity login is shown. Only works for apps using Sign in with Gipity, hosted on *.gipity.ai.')
   .option('--ephemeral', 'Skip the project screenshot history: do not persist this capture to Gipity (screenshots/ in the project). Local file is still written.')
   .option('--json', 'Output JSON metadata instead of a friendly summary')
@@ -268,13 +270,28 @@ export const pageScreenshotCommand = new Command('screenshot')
     const projectGuid = getConfig()?.projectGuid;
     const save = !opts.ephemeral && projectGuid ? { project_guid: projectGuid, names } : undefined;
 
+    // The webcam frame is hosted in the project's public file store for the
+    // browser container to fetch, so it needs a linked project. Validate the
+    // file locally first — a bad file type costs one instant error, not an
+    // upload plus an opaque browser-side failure.
+    let camera: HostedFixture | undefined;
+    if (opts.camera) {
+      assertCameraFile(opts.camera);
+      if (!projectGuid) throw new Error('--camera needs a linked project (the frame is hosted for the browser to fetch) — run `gipity link` first.');
+      console.log(muted(`Hosting camera feed ${opts.camera}…`));
+      camera = await uploadCameraFeed(projectGuid, opts.camera);
+    }
+
     const body = {
       url,
       postLoadDelayMs,
       full: !!(opts.full || opts.fullPage),
       reloadBetween: opts.reloadBetween !== false,
       ...(userSpecifiedViewports ? { viewports: customViewports } : {}),
-      ...(opts.fakeMedia ? { fakeMedia: true } : {}),
+      // A camera feed is played into the synthetic devices, so --camera implies
+      // --fake-media rather than failing on the pairing.
+      ...(opts.fakeMedia || camera ? { fakeMedia: true } : {}),
+      ...(camera ? { cameraUrl: camera.url } : {}),
       ...(opts.auth ? { auth: true } : {}),
       ...(opts.action ? { action: opts.action } : {}),
       ...(save ? { save } : {}),
@@ -284,9 +301,20 @@ export const pageScreenshotCommand = new Command('screenshot')
     // seconds; animate the wait, then clear so the saved-files summary is the
     // result. JSON mode skips the spinner (shares stdout).
     const doShoot = () => postForTarEntries('/tools/browser/screenshot', body);
-    const entries = opts.json
-      ? await doShoot()
-      : await withSpinner('Capturing…', doShoot, { done: null });
+    let entries;
+    try {
+      entries = opts.json
+        ? await doShoot()
+        : await withSpinner('Capturing…', doShoot, { done: null });
+    } finally {
+      if (camera) {
+        try {
+          await deleteFixture(projectGuid!, camera.guid);
+        } catch (err) {
+          console.error(warning(`⚠ Could not auto-delete camera feed "${camera.name}" (${camera.guid}) — still hosted at ${camera.url}: ${(err as Error).message}`));
+        }
+      }
+    }
 
     const metaEntry = entries.find((e) => e.name === 'meta.json');
     if (!metaEntry) throw new Error('Server response missing meta.json');

--- a/src/page-fixtures.ts
+++ b/src/page-fixtures.ts
@@ -61,3 +61,45 @@ export async function uploadPublicFixture(projectGuid: string, localPath: string
 export async function deleteFixture(projectGuid: string, guid: string): Promise<void> {
   await del(`/api/${projectGuid}/uploads/${guid}`);
 }
+
+// ── camera feed ─────────────────────────────────────────────────────────────
+// A headless browser has no webcam, so a vision app (MediaPipe, YOLOX, any
+// getUserMedia consumer) can't be exercised at all: getUserMedia rejects, the
+// app shows its no-camera state, and the code path the user actually cares
+// about never runs. `--fake-media` alone only fixes the rejection — Chrome's
+// built-in synthetic device is a rolling test pattern, so a gesture/pose/object
+// model still sees nothing recognizable and every agent ends up stubbing the
+// model's own output to test around it.
+//
+// --camera closes that: host a real image/video and let the browser play it as
+// the webcam's frames, so the app's REAL pipeline (frames → model → app logic)
+// runs headlessly on input you control. Hosting reuses the fixture path above;
+// the browser side (fetch the file, feed it to Chrome's fake capture device)
+// is the server's job — the CLI just names the file and hands over its URL.
+
+/** Container formats Chrome's fake video-capture device can be fed from, plus
+ *  the still-image types the server transcodes into a looping single-frame
+ *  feed. Anything else is rejected here (fast, local) rather than after an
+ *  upload + a browser launch. */
+const CAMERA_EXTS = ['.png', '.jpg', '.jpeg', '.webp', '.mp4', '.webm', '.y4m', '.mjpeg'];
+
+/** Validate a --camera path before uploading it. Throws with the accepted list
+ *  and the in-platform way to produce a frame, so a wrong file type costs one
+ *  local error instead of an upload plus an opaque browser failure. */
+export function assertCameraFile(localPath: string): void {
+  const ext = localPath.slice(localPath.lastIndexOf('.')).toLowerCase();
+  if (CAMERA_EXTS.includes(ext)) return;
+  throw new Error(
+    `--camera ${basename(localPath)}: unsupported file type "${ext || '(none)'}" — the camera feed must be an image or video (${CAMERA_EXTS.join(', ')}).\n` +
+    `A still image is played as a looping single-frame feed, which is what a gesture/pose/object model needs.\n` +
+    `No frame to hand? Generate one: gipity generate image "a hand making a closed fist, palm to camera, plain background"`,
+  );
+}
+
+/** Host a local image/video as the browser's webcam feed. Same public-upload
+ *  path as a fixture (so it is fetchable from the browser container and is
+ *  deleted the same way), validated first. */
+export async function uploadCameraFeed(projectGuid: string, localPath: string): Promise<HostedFixture> {
+  assertCameraFile(localPath);
+  return uploadPublicFixture(projectGuid, localPath);
+}


### PR DESCRIPTION
Found by GipRunner fix-mode on free/15-vision-rps-duel: building a camera app, the
agent could not verify it. `--use-fake-device-for-media-stream` only ever gave the
page Chrome's rolling test pattern — a stream exists, but nothing a gesture/pose/object
model can recognise — so the skill docs TOLD agents to compile debug hooks onto
`window` and hand-feed synthetic MediaPipe results. That isn't verification: the app's
real camera → inference → UI path never runs, and the user ships an app carrying a test
surface.

- server: new fake-camera service — fetch an image (SSRF-guarded, 25 MB cap), sharp →
  single-frame I420 Y4M, written into the browser container; Chrome launches with
  --use-file-for-fake-video-capture and loops it as a steady webcam. `cameraUrl` is
  accepted on inspect/eval/screenshot; `page eval` had no synthetic-media support at
  all, so a vision app could not even be driven. A bad image is a synchronous 400, not
  a mystery inside a polled job.
- cli: `--camera <path>` on page eval/screenshot (uploads via the hosted-fixture path).
  A vision app's real getUserMedia → model → logic path can now be exercised without
  stubbing the model or exporting app internals.
- server: favicons render in-process with sharp (~40ms) instead of a code-sandbox
  container + two ImageMagick shells (~10s on the first add for a title); the per-letter
  cache that existed only to hide that cost is gone.
- docs: app-debugging, web-vision-mediapipe and web-vision-detect drop the
  "the camera path can't be tested headlessly — expose your logic on window" guidance
  for one `--camera` line each. All three docs are SHORTER — the platform now does the
  thing they taught agents to work around.
- test: app-file-uploads' `jest.mock('sharp')` factory is hoisted above its own
  mockSharpInstance const, so it TDZ-crashed as soon as template.ts pulled sharp into
  the import graph. Defer the reference to call time.

New tests assert the exact Y4M header/frame bytes and that the image reaches the luma
plane — a wrong header makes Chrome silently play black, which would "verify" a vision
app that sees nothing.

Opened by `gw`. Gate: passed.

Closes #140