### PR TITLE
giprunner fix-mode: 5-app sweep (free/02+05+06+13+21), rounds 1-2

### DIFF
--- a/src/__tests__/cli-cmd-page.test.ts
+++ b/src/__tests__/cli-cmd-page.test.ts
@@ -1227,20 +1227,20 @@ test('gipity page screenshot omits action from the body when --action is absent'
   assert.equal((req!.body as { action?: string }).action, undefined);
 });
 
-test('gipity page screenshot rejects a guessed JS-intent flag but still shows the state-capture guidance', async () => {
-  // --js and friends are hidden decoys: rather than a bare "unknown option",
-  // the error names the real flag (--action), and still renders this command's
-  // help (with the 'after' block) so the very first guess lands on the answer.
-  // (--eval is no longer a decoy — it's the sibling subcommand's name for this
-  // exact capability, so it works as an alias; see the alias tests.)
+test('gipity page screenshot treats a guessed --eval flag as a working --action alias', async () => {
+  // --eval is the reflex guess (agents know it from `page eval`) and the intent
+  // is unambiguous — run this JS before the shot — so it must WORK as a hidden
+  // alias for --action, not cost a redirect turn. A muted note names the
+  // canonical flag. (--js and the other JS-intent guesses work the same way —
+  // this superseded the earlier reject-and-redirect decoys.)
   mock.reset();
-  const r = await run(['page', 'screenshot', 'https://example.com', '--js', 'foo']);
-  assert.notEqual(r.status, 0);
-  assert.match(r.stderr, /--js is not a flag on screenshot/);
-  assert.match(r.stderr, /--action/);
-  assert.match(r.stderr, /page eval|--full captures the ENTIRE scrollable page/);
-  // It must NOT have actually captured against the server.
-  assert.equal(mock.requests().some((q) => q.url === '/tools/browser/screenshot'), false);
+  await mockScreenshot();
+  const script = "document.getElementById('play').click()";
+  const r = await run(['page', 'screenshot', 'https://example.com', '--eval', script, '-o', join(home, 'alias.png')]);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stderr, /treating --eval as --action/);
+  const req = mock.requests().find((q) => q.url === '/tools/browser/screenshot');
+  assert.equal((req!.body as { action?: string }).action, script, 'the aliased script must reach the server as the pre-capture action');
 });
 
 // ── screenshot VFS history (save payload) ──────────────────────────────────
@@ -1578,12 +1578,17 @@ test('gipity page screenshot accepts --eval as an alias for --action', async () 
   assert.equal((req!.body as { action?: string }).action, js, '--eval must reach the server as the action script');
 });
 
-test('gipity page screenshot rejects --action and --eval together', async () => {
+test('gipity page screenshot composes --action and --eval into one pre-capture script', async () => {
+  // Aliases FOLD rather than conflict: both scripts are the same in-page
+  // primitive, so passing --action and --eval together runs both (joined),
+  // instead of erroring — an agent that mixed the spellings still gets its shot.
   mock.reset();
   await mockScreenshot();
-  const r = await run(['page', 'screenshot', 'https://example.com', '--action', 'a()', '--eval', 'b()']);
-  assert.notEqual(r.status, 0);
-  assert.match(r.stderr + r.stdout, /not both/);
+  const r = await run(['page', 'screenshot', 'https://example.com', '--action', 'a()', '--eval', 'b()', '-o', join(home, 'compose.png')]);
+  assert.equal(r.status, 0, r.stderr);
+  const req = mock.requests().find((q) => q.url === '/tools/browser/screenshot');
+  const action = (req!.body as { action?: string }).action ?? '';
+  assert.ok(action.includes('a()') && action.includes('b()'), 'both scripts must reach the server in one action');
 });
 
 test('gipity page eval redirects --action (the screenshot spelling) to the positional <expr>', async () => {
@@ -1796,4 +1801,50 @@ test('an eval that outlives the client budget never advises lowering --wait', as
       return true;
     },
   );
+});
+
+// ── --width/--height as a working --viewport alias ─────────────────────────────
+// "How does this look on a phone?" is the most common screenshot ask, and the
+// setViewport vocabulary (--width 390 --height 844) is the flag pair agents
+// guess first. It must WORK — a bounce to --help here means the phone layout
+// the user asked about never gets verified at phone width.
+test('gipity page screenshot --width/--height works as a --viewport alias', async () => {
+  mock.reset();
+  await mockScreenshot();
+  const r = await run(['page', 'screenshot', 'https://example.com', '--width', '390', '--height', '844', '-o', join(home, 'shot.png')]);
+  assert.equal(r.status, 0, r.stderr);
+  const vps = (mock.requests().find((q) => q.url === '/tools/browser/screenshot')!.body as ShotBody).viewports!;
+  assert.equal(vps.length, 1);
+  assert.equal(vps[0].width, 390);
+  assert.equal(vps[0].height, 844);
+  // A raw window is not a handset — the phone-width path points at --device mobile.
+  assert.match(r.stderr, /--device mobile/);
+});
+
+test('gipity page screenshot rejects half a --width/--height pair with the full vocabulary', async () => {
+  mock.reset();
+  await mockScreenshot();
+  const r = await run(['page', 'screenshot', 'https://example.com', '--width', '390']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /--width and --height go together/);
+  assert.match(r.stderr, /--viewport WxH/);
+  assert.match(r.stderr, /--device mobile/);
+});
+
+// ── eval completion-value semantics ────────────────────────────────────────────
+// Completion-value rewriting (auto-returning a trailing bare expression) lives
+// SERVER-side, for every caller. The CLI must send the script exactly as
+// written — a second, weaker rewrite here would drift from the real semantics.
+test('gipity page eval sends a no-return body verbatim (server owns auto-return)', async () => {
+  mock.reset();
+  mock.on('POST /tools/browser/eval', { body: { data: { evalJobId: 'job-1', status: 'queued' } } });
+  mock.on('GET /tools/browser/eval/job-1', { body: { data: {
+    status: 'done', url: 'https://example.com', result: '{"n":2}', truncated: false,
+  } } });
+  const script = 'const n = 1 + 1; ({ n })';
+  const r = await run(['page', 'eval', 'https://example.com', script]);
+  assert.equal(r.status, 0, r.stderr);
+  const sent = (mock.requests().find((q) => q.url === '/tools/browser/eval')!.body as { expr: string }).expr;
+  assert.equal(sent, script, 'the script must reach the server unrewritten');
+  assert.match(r.stdout, /\{"n":2\}/);
 });

--- a/src/__tests__/cli-cmd-sandbox.test.ts
+++ b/src/__tests__/cli-cmd-sandbox.test.ts
@@ -1,6 +1,6 @@
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { writeFileSync, mkdirSync } from 'node:fs';
+import { writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { join, dirname } from 'node:path';
 import { runCliAsync, makeTmpHome } from './helpers/spawn-cli.js';
@@ -350,14 +350,14 @@ test('gipity sandbox run rejects a scratch --input path without touching the API
   assert.deepEqual(mock.requests(), [], 'no API call should precede the scratch-input check');
 });
 
-// ── --no-sync-output: per-run "don't persist this output" globs ──────────────
+// ── --discard-output: per-run "drop this output entirely" globs ──────────────
 //
 // The filtering happens SERVER-side (in the output extractor) - a client-side
 // skip would still write the files into project storage and churn every later
-// sync. So the CLI's whole job is (a) sending the globs in the POST body and
-// (b) reporting what the server says it dropped.
+// sync. So the CLI's whole job is (a) sending the globs in the POST body
+// (wire name: noSyncOutput) and (b) reporting what the server says it dropped.
 
-test('gipity sandbox run sends --no-sync-output globs in the POST body and prints the skipped list', async () => {
+test('gipity sandbox run sends --discard-output globs in the POST body and prints the discarded list', async () => {
   resetMock();
   let posted: { noSyncOutput?: string[] } | undefined;
   mock.on('POST /projects/p_TestProj/sandbox/execute', async (req) => {
@@ -365,16 +365,16 @@ test('gipity sandbox run sends --no-sync-output globs in the POST body and print
     return { body: { data: {
       exitCode: 0, stdout: '', stderr: '', durationMs: 10, timedOut: false,
       outputFiles: ['docs/report.pdf'],
-      skippedOutputFiles: ['docs/preview-1.png', 'docs/preview-2.png'],
+      skippedOutputFiles: ['docs/frames-1.ppm', 'docs/frames-2.ppm'],
     } } };
   });
-  const r = await fresh(['sandbox', 'run', 'bash', 'pdftoppm -png docs/report.pdf docs/preview',
-    '--no-sync-output', 'docs/preview*', '--no-sync-output', '*.ppm']);
+  const r = await fresh(['sandbox', 'run', 'bash', 'pdftoppm docs/report.pdf docs/frames',
+    '--discard-output', 'docs/frames*', '--discard-output', '*.ppm']);
   assert.equal(r.status, 0, r.stderr);
-  assert.deepEqual(posted?.noSyncOutput, ['docs/preview*', '*.ppm'], 'both repeated globs must reach the server');
-  assert.match(r.stdout, /Not persisted \(--no-sync-output\):/);
-  assert.match(r.stdout, /docs\/preview-1\.png/);
-  assert.match(r.stdout, /docs\/preview-2\.png/);
+  assert.deepEqual(posted?.noSyncOutput, ['docs/frames*', '*.ppm'], 'both repeated globs must reach the server');
+  assert.match(r.stdout, /Discarded \(--discard-output\):/);
+  assert.match(r.stdout, /docs\/frames-1\.ppm/);
+  assert.match(r.stdout, /docs\/frames-2\.ppm/);
   // The kept output still prints under the normal heading.
   assert.match(r.stdout, /docs\/report\.pdf/);
 });
@@ -390,15 +390,54 @@ test('gipity sandbox run omits noSyncOutput from the POST body when the flag is 
   assert.equal(r.status, 0, r.stderr);
   assert.ok(posted, 'expected the execute call');
   assert.ok(!('noSyncOutput' in posted!), 'no flag means no noSyncOutput key - server default behavior');
-  assert.doesNotMatch(r.stdout, /Not persisted/);
+  assert.doesNotMatch(r.stdout, /Discarded/);
 });
 
-test('gipity sandbox run rejects an empty --no-sync-output glob without touching the API', async () => {
+test('gipity sandbox run rejects an empty --discard-output glob without touching the API', async () => {
   mock.reset();
-  const r = await outsideProject(['sandbox', 'run', '--language', 'bash', 'echo hi', '--no-sync-output', '']);
+  const r = await outsideProject(['sandbox', 'run', '--language', 'bash', 'echo hi', '--discard-output', '']);
   assert.equal(r.status, 1);
   assert.match(r.stderr, /non-empty glob/);
   assert.deepEqual(mock.requests(), [], 'no API call should precede glob validation');
+});
+
+// ── scratch outputs: tmp/ files come back local-only, never into the project ─
+//
+// The server never persists scratch-namespace outputs to project storage;
+// instead it returns their bytes inline (scratchFiles) and the CLI lands them
+// at the same relative path locally, where sync ignores them in both
+// directions. This is the "inspect an artifact without keeping it" path.
+
+test('gipity sandbox run materializes inline scratchFiles locally and reports them as local-only', async () => {
+  resetMock();
+  const d = makeProjectDir({ apiBase: mock.apiBase });
+  mock.on('POST /projects/p_TestProj/sandbox/execute', { body: { data: {
+    exitCode: 0, stdout: '', stderr: '', durationMs: 10, timedOut: false,
+    scratchFiles: [
+      { path: 'tmp/preview-1.png', contentBase64: Buffer.from('png-bytes').toString('base64') },
+      { path: 'tmp/../../evil.txt', contentBase64: Buffer.from('nope').toString('base64') },
+    ],
+  } } });
+  const r = await runCliAsync(['--api-base', mock.apiBase, 'sandbox', 'run', 'bash', 'pdftoppm -png docs/report.pdf tmp/preview'], { env: { HOME: home }, cwd: d });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(readFileSync(join(d, 'tmp/preview-1.png'), 'utf8'), 'png-bytes', 'scratch bytes must land at the local path');
+  assert.ok(!existsSync(join(d, '..', 'evil.txt')), 'a traversal path must not escape the project root');
+  assert.match(r.stdout, /Scratch outputs \(local only/);
+  assert.match(r.stdout, /tmp\/preview-1\.png/);
+});
+
+test('gipity sandbox run --json reports scratchFiles as the list of locally written paths', async () => {
+  resetMock();
+  const d = makeProjectDir({ apiBase: mock.apiBase });
+  mock.on('POST /projects/p_TestProj/sandbox/execute', { body: { data: {
+    exitCode: 0, stdout: '', stderr: '', durationMs: 10, timedOut: false,
+    scratchFiles: [{ path: 'tmp/x.txt', contentBase64: Buffer.from('x').toString('base64') }],
+  } } });
+  const r = await runCliAsync(['--api-base', mock.apiBase, 'sandbox', 'run', 'bash', 'echo x > tmp/x.txt', '--json'], { env: { HOME: home }, cwd: d });
+  assert.equal(r.status, 0, r.stderr);
+  const out = JSON.parse(r.stdout);
+  assert.deepEqual(out.scratchFiles, ['tmp/x.txt'], '--json must list paths, not base64 payloads');
+  assert.equal(readFileSync(join(d, 'tmp/x.txt'), 'utf8'), 'x');
 });
 
 test('gipity sandbox run allows a non-scratch input that merely starts with "tmp"', async () => {
@@ -410,4 +449,36 @@ test('gipity sandbox run allows a non-scratch input that merely starts with "tmp
 
   assert.equal(r.status, 0);
   assert.match(r.stdout, /ok/);
+});
+
+// ── --code as a working alias for the positional inline code ──────────────────
+// `--code "<code>"` is the natural first guess for inline code; it must run the
+// code, not bounce into an unknown-option --help detour.
+test('gipity sandbox run --code works as an alias for the positional inline code', async () => {
+  resetMock();
+  mock.on('POST /projects/p_TestProj/sandbox/execute', async (req) => {
+    const body = req.body as { code: string; language: string };
+    assert.equal(body.code, 'print(7)');
+    assert.equal(body.language, 'python');
+    return { body: { data: { exitCode: 0, stdout: '7', stderr: '', durationMs: 50, timedOut: false } } };
+  });
+  const r = await fresh(['sandbox', 'run', '--language', 'py', '--code', 'print(7)']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /7/);
+});
+
+test('gipity sandbox run --code still requires a pinned language, pre-network', async () => {
+  resetMock();
+  const r = await fresh(['sandbox', 'run', '--code', 'import this']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /No language specified/);
+  assert.equal(mock.requests().length, 0, 'must fail before any API call');
+});
+
+test('gipity sandbox run rejects --code plus a positional arg', async () => {
+  resetMock();
+  const r = await fresh(['sandbox', 'run', '--language', 'py', '--code', 'print(1)', 'print(2)']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /either positionally or via --code/);
+  assert.equal(mock.requests().length, 0, 'must fail before any API call');
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test';
+import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
@@ -137,6 +137,18 @@ describe('isAllowedApiHost (token-redirect guard)', () => {
 });
 
 describe('resolveApiBase (untrusted .gipity.json apiBase is ignored)', () => {
+  // GIPITY_API_BASE is a trusted env override that outranks the config file -
+  // an ambient value (e.g. a dev shell pointed at a local server) would mask
+  // the config-fallback behavior under test, so clear it for these tests.
+  let origEnvBase: string | undefined;
+  before(() => {
+    origEnvBase = process.env.GIPITY_API_BASE;
+    delete process.env.GIPITY_API_BASE;
+  });
+  after(() => {
+    if (origEnvBase !== undefined) process.env.GIPITY_API_BASE = origEnvBase;
+  });
+
   it('falls back to the default when a poisoned config points off-allowlist', () => {
     const cwd0 = process.cwd();
     const dir = mkdtempSync(join(tmpdir(), 'gip-apibase-'));

--- a/src/__tests__/setup-skills-block.test.ts
+++ b/src/__tests__/setup-skills-block.test.ts
@@ -9,7 +9,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { applySkillsBlock, applyAiderConf, GIPITY_BLOCK_BEGIN, GIPITY_BLOCK_END, SKILLS_CONTENT, PRIMER_FILES, AIDER_CONF_FILE, DEFAULT_SYNC_IGNORE, SUPPORTED_TOOLS, DEFAULT_TOOLS } from '../setup.js';
-import { shouldIgnore } from '../config.js';
+import { shouldIgnore, DEFAULT_API_BASE } from '../config.js';
 
 function count(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
@@ -57,6 +57,40 @@ test('user file with no Gipity block: block appended, user content kept', () => 
   assert.ok(out.startsWith('# My Project'), 'user content stays at the top');
   assert.ok(out.includes('Just my notes, no Gipity block.'), 'user content kept');
   assert.ok(out.includes(GIPITY_BLOCK_BEGIN), 'managed block appended');
+});
+
+// ── Non-default API base ─────────────────────────────────────────────────
+// The knowledge text names the public a.gipity.ai services endpoint. A session
+// pointed at another platform instance (GIPITY_API_BASE / --api-base, e.g. a
+// local dev server) must render the block against THAT base and say so, or the
+// agent copies the public host into app code and gets 404s for a project that
+// only exists on the other instance.
+
+test('non-default api base: service URLs rewritten and the instance is named', () => {
+  const base = 'http://localhost:7301';
+  const out = applySkillsBlock(null, base);
+  assert.ok(out.includes(`${base}/api/<PROJECT_GUID>/services/*`), 'services endpoint points at the instance');
+  assert.ok(out.includes(`${DEFAULT_API_BASE}/api/`) === false, 'no service URL left on the public host');
+  assert.ok(out.includes('**Platform instance:**'), 'the instance note is present');
+  assert.ok(out.includes(`\`${base}\``), 'the note names the actual base');
+});
+
+test('non-default api base: trailing slash is normalized away', () => {
+  const out = applySkillsBlock(null, 'http://localhost:7301/');
+  assert.ok(out.includes('http://localhost:7301/api/<PROJECT_GUID>/services/*'), 'no double slash in URLs');
+});
+
+test('default api base: block is untouched, no instance note', () => {
+  const out = applySkillsBlock(null, DEFAULT_API_BASE);
+  assert.equal(out, applySkillsBlock(null), 'explicit default matches the no-arg render');
+  assert.ok(!out.includes('**Platform instance:**'), 'no note for the public platform');
+});
+
+test('non-default api base: idempotent, and switching base rewrites the block', () => {
+  const local = applySkillsBlock(null, 'http://localhost:7301');
+  assert.equal(applySkillsBlock(local, 'http://localhost:7301'), local, 'same base re-apply is a no-op');
+  const backToProd = applySkillsBlock(local, DEFAULT_API_BASE);
+  assert.ok(!backToProd.includes('localhost:7301'), 'stale instance URLs are replaced');
 });
 
 test('idempotent: re-applying the result changes nothing', () => {

--- a/src/__tests__/sync-apply.test.ts
+++ b/src/__tests__/sync-apply.test.ts
@@ -14,18 +14,25 @@ import { tmpdir } from 'os';
 let home: string;
 let projectDir: string;
 let origHome: string | undefined;
+let origGipityDir: string | undefined;
 let origCwd: string;
 let origFetch: typeof globalThis.fetch;
 let origTTY: boolean | undefined;
 
 before(() => {
   origHome = process.env.HOME;
+  origGipityDir = process.env.GIPITY_DIR;
   origCwd = process.cwd();
   origFetch = globalThis.fetch;
   origTTY = process.stdout.isTTY;
 
   home = mkdtempSync(join(tmpdir(), 'gipity-apply-home-'));
   process.env.HOME = home;
+  // GIPITY_DIR points auth.ts at a real agent context (auth.json) outside the
+  // faked HOME - a near-expiry real token would fire refresh POSTs into the
+  // fetch stub and fail the "no HTTP writes" assertions. Tests must read only
+  // the fake auth written below.
+  delete process.env.GIPITY_DIR;
   mkdirSync(join(home, '.gipity'), { recursive: true });
   writeFileSync(join(home, '.gipity', 'auth.json'), JSON.stringify({
     accessToken: 'fake-jwt',
@@ -56,6 +63,7 @@ after(() => {
   globalThis.fetch = origFetch;
   if (origHome === undefined) delete process.env.HOME;
   else process.env.HOME = origHome;
+  if (origGipityDir !== undefined) process.env.GIPITY_DIR = origGipityDir;
   if (origTTY !== undefined) {
     Object.defineProperty(process.stdout, 'isTTY', { value: origTTY, configurable: true });
   }

--- a/src/commands/page-eval.ts
+++ b/src/commands/page-eval.ts
@@ -27,9 +27,11 @@ export interface EvalResult {
 
 // Shown when an eval runs cleanly but returns nothing serializable. Turns a
 // bare/opaque `null` into a deterministic, actionable nudge so the agent shapes
-// a returnable value instead of guessing and retrying.
+// a returnable value instead of guessing and retrying. (A body ending in a bare
+// expression is auto-returned SERVER-side before this can fire — so this is the
+// residue: block/loop endings, explicit undefined returns, DOM nodes, functions.)
 export const EVAL_NO_VALUE_HINT =
-  'The eval ran but returned no JSON-serializable value. A statement body with no `return`, an assignment, a void call, or a DOM node/function all serialize to null. ' +
+  'The eval ran but returned no JSON-serializable value. A body ending in a loop/if-block, a `return` of undefined, or a DOM node/function all serialize to null. ' +
   'End the script with an expression — or an explicit `return` — that yields plain data, e.g. `return { label: input.value, count: items.length }` or `return JSON.stringify(payload)`.';
 
 /** Normalize a raw eval result for display. The eval can come back as a useful
@@ -417,7 +419,7 @@ const JS_DECOY_FLAGS = ['--js', '--javascript', '--script', '--code', '--expr', 
 export const pageEvalCommand = new Command('eval')
   .description('Evaluate JS in a real browser on a page (DOM, computed styles, element rects; inline expr or --file script). ONE client per call - to verify realtime/presence across concurrent clients use `page test --observe` instead')
   .argument('<url>', 'URL to load')
-  .argument('[expr]', `JavaScript to evaluate in page context (inline expression or statement body with return/await; result is JSON-serialized). Omit when using --file. Time budget: the body has ${EVAL_SCRIPT_BUDGET_MS / 1000}s to finish after page load (${EVAL_SCRIPT_BUDGET_CAMERA_MS / 1000}s with --camera) - raise it with --timeout, max ${EVAL_SCRIPT_BUDGET_MAX_MS / 1000}s.`)
+  .argument('[expr]', `JavaScript to evaluate in page context (inline expression or statement body; await works, and the trailing expression is returned automatically — REPL-style — so no explicit return is needed; result is JSON-serialized). Omit when using --file. Time budget: the body has ${EVAL_SCRIPT_BUDGET_MS / 1000}s to finish after page load (${EVAL_SCRIPT_BUDGET_CAMERA_MS / 1000}s with --camera) - raise it with --timeout, max ${EVAL_SCRIPT_BUDGET_MAX_MS / 1000}s.`)
   .option('--file <path>', `Read the script body from a file instead of the inline <expr> arg (mutually exclusive). Runs as an async function body, so top-level return/await work. Same post-load budget as <expr> (--timeout).`)
   .option(
     '--step <expr>',
@@ -559,6 +561,9 @@ export const pageEvalCommand = new Command('eval')
     // cleaned up, without shifting the fixture map the caller indexes into.
     let camera: HostedFixture | undefined;
     let projectGuid: string | undefined;
+    // Completion-value semantics (a body ending in a bare expression returns it,
+    // REPL-style) are applied SERVER-side to every leg — one source of truth for
+    // every caller; the CLI sends the script as written.
     let sentExpr = expr;
     let sentSteps = steps;
     // Validate the camera file locally first: a wrong file type should cost one

--- a/src/commands/page-screenshot.ts
+++ b/src/commands/page-screenshot.ts
@@ -224,14 +224,13 @@ function appendOption(value: string, previous: string[] = []): string[] {
 }
 
 // Pre-capture scripting lives on --action, but agents reach for the JS-intent
-// names first and an "unknown option" alone doesn't name the right flag. Capture
-// the common guesses as hidden decoys (taking a value, so they swallow the
-// script) and redirect precisely — same pattern as `page eval`'s JS_DECOY_FLAGS.
-// `--eval` is NOT a decoy: it's the sibling subcommand's name for this exact
-// capability, an agent fresh off `page eval <url> "<js>"` reaches for it every
-// time, and there is no ambiguity about what they meant — so it just works
-// (hidden alias for --action, registered below).
-const ACTION_DECOY_FLAGS = ['--js', '--javascript', '--script', '--code', '--exec'];
+// names first — --eval above all, the name they already know from `page eval`.
+// The intent is unambiguous (run this JS in the page before the shot), so these
+// are working hidden aliases, not errors — same accept-the-reflex-guess pattern
+// as --full-page and --width/--height. (Supersedes the earlier decoy approach,
+// which swallowed the script and errored with a redirect: when the guess is
+// unambiguous, making it WORK beats making it a better error.)
+const ACTION_ALIAS_FLAGS = ['--eval', '--js', '--javascript', '--script', '--code', '--exec'];
 
 /** A capture is worthless if it fires before the app reaches the state you meant
  *  to photograph, and the only lever used to be a blind millisecond delay — so a
@@ -275,6 +274,12 @@ export const CAMERA_DEFAULT_DELAY_MS = 15_000;
 export const pageScreenshotCommand = new Command('screenshot')
   .description('Screenshot a web page')
   .argument('<url>', 'URL to screenshot')
+  // --device / --viewport lead the options: "how does this look on a phone?" is
+  // the single most common reason to screenshot, and agents routinely read the
+  // help through `--help | head -N` — buried below the timing flags, these two
+  // fell off the bottom and the run proceeded at desktop width.
+  .option('--device <names>', `Device preset(s): ${Object.keys(DEVICE_PRESETS).join(', ')} (comma-separated or repeat flag). mobile/tablet emulate a real touch device — touch events, mobile user-agent, DPR — so touch-gated mobile UI actually renders.`, appendOption, [] as string[])
+  .option('--viewport <dims>', 'Raw viewport(s): WxH or WxH@dpr (comma-separated or repeat flag), e.g. --viewport 390x844 for a phone-sized window', appendOption, [] as string[])
   // No commander default: a default here would make the value always set, so the
   // merge below could not tell "caller chose a delay" from "nobody did" — which
   // is what --camera's model-load default and the --wait-for gate both hinge on.
@@ -284,8 +289,6 @@ export const pageScreenshotCommand = new Command('screenshot')
   .option('--action <js>','Run JS in the page before capturing — e.g. click a button to enter a state ("document.getElementById(\'play\').click()"). Runs as an async function body, so const/await and app-relative import(\'./…\') work. Runs after the post-load delay, then settles again before the shot. If it throws, the capture still happens and the failure is reported.')
   .option('--full', 'Capture the full scrollable page (default: viewport only). Scrolls the page through first so scroll-reveal/fade-in-on-scroll (IntersectionObserver) sections render into the shot instead of capturing blank.')
   .option('-o, --output <file>', 'Output path (single viewport only; default .gipity/screenshots/ss-<host>-<timestamp>.png)')
-  .option('--device <names>', `Device preset(s): ${Object.keys(DEVICE_PRESETS).join(', ')} (comma-separated or repeat flag). mobile/tablet emulate a real touch device — touch events, mobile user-agent, DPR — so touch-gated mobile UI actually renders.`, appendOption, [] as string[])
-  .option('--viewport <dims>', 'Raw viewport(s): WxH or WxH@dpr (comma-separated or repeat flag)', appendOption, [] as string[])
   .option('--no-reload-between', 'Skip reload between viewports (faster, lower fidelity - only safe for static pages)')
   .option('--fake-media', 'Grant a synthetic microphone + camera and auto-accept the getUserMedia prompt, so voice/camera apps render headlessly. The video feed is a built-in test pattern — to capture what the app does with a REAL frame (a hand, a face, an object), use --camera <path> instead.')
   .option('--camera <path>', 'Play a local image or video (.png/.jpg/.webp/.mp4/.webm/.y4m/.mjpeg) as the browser\'s WEBCAM feed, then capture — so the shot shows the app reacting to a frame you chose (detected gesture, boxes, labels). Implies --fake-media.')
@@ -293,24 +296,30 @@ export const pageScreenshotCommand = new Command('screenshot')
   .option('--ephemeral', 'Skip the project screenshot history: do not persist this capture to Gipity (screenshots/ in the project). Local file is still written.')
   .option('--json', 'Output JSON metadata instead of a friendly summary')
   .addOption(new Option('--post-load-delay <ms>', 'Alias for --wait').hideHelp())
-  // `page eval` spells run-JS-on-the-page as its own name, so an agent that just
-  // used it guesses `--eval` here. Same capability, unambiguous intent — accept
-  // it as a hidden alias instead of burning a turn on a redirect error.
-  .addOption(new Option('--eval <js>', 'Alias for --action').hideHelp())
+  // (--eval and the other JS-intent guesses are registered in one place from
+  // ACTION_ALIAS_FLAGS below — a second standalone registration here makes
+  // commander throw "conflicting flag" at startup.)
   // `--full-page` is the Puppeteer/Playwright name for this (their `fullPage`),
   // so agents reach for it by reflex. Accept it as a hidden alias for `--full`
   // rather than reject it as an unknown option and send them on a --help detour.
   .addOption(new Option('--full-page', 'Alias for --full').hideHelp())
+  // `--width 390 --height 844` is the setViewport vocabulary agents guess first
+  // when asked for a phone-sized shot. Accept the pair as a working alias for
+  // --viewport WxH instead of bouncing the guess into a --help detour.
+  .addOption(new Option('--width <px>', 'Alias: --viewport WxH').hideHelp())
+  .addOption(new Option('--height <px>', 'Alias: --viewport WxH').hideHelp())
   .action((url: string, opts) => run('Page screenshot', async () => {
-    // A JS-intent flag guess (captured as a hidden decoy below): name the real
-    // flag before any other arg-shape check fires.
-    const decoy = ACTION_DECOY_FLAGS.find((f) => opts[f.slice(2)] !== undefined);
-    if (decoy) {
-      pageScreenshotCommand.error(
-        `error: ${decoy} is not a flag on screenshot — use --action "<js>" to run JavaScript in the page ` +
-        `before the capture, e.g. gipity page screenshot "<url>" --action "document.getElementById('play').click()"`,
-      );
+    // A JS-intent alias guess (--eval et al., hidden): fold it into the action
+    // script so the reflex guess just works, and name the canonical flag once
+    // so the next call uses it.
+    const aliasFlag = ACTION_ALIAS_FLAGS.find((f) => opts[f.slice(2)] !== undefined);
+    if (aliasFlag) {
+      console.error(muted(
+        `Note: treating ${aliasFlag} as --action — it runs your JS in the page before the capture. --action is the canonical flag.`,
+      ));
     }
+    const actionScript = [opts.action, ...ACTION_ALIAS_FLAGS.map((f) => opts[f.slice(2)])]
+      .filter(Boolean).join('\n');
     // --wait is the canonical name (it is what `page inspect`/`page eval` call it);
     // --post-load-delay stays as a hidden alias. Whether the caller named EITHER is
     // what decides the defaults below, so keep the raw "was it set" signal.
@@ -358,6 +367,26 @@ export const pageScreenshotCommand = new Command('screenshot')
 
     const deviceNames = splitCsv(opts.device as string[]);
     const viewportStrs = splitCsv(opts.viewport as string[]);
+    // --width/--height: fold the alias pair into a --viewport entry. Half a
+    // pair is a mis-invocation worth one precise line, not a range error.
+    if (opts.width !== undefined || opts.height !== undefined) {
+      if (opts.width === undefined || opts.height === undefined) {
+        pageScreenshotCommand.error(
+          'error: --width and --height go together (both in px, equivalent to --viewport WxH) — ' +
+          'or use a preset like --device mobile for a real handset (touch events, mobile user-agent, DPR)',
+        );
+      }
+      if (!/^\d+$/.test(String(opts.width)) || !/^\d+$/.test(String(opts.height))) {
+        pageScreenshotCommand.error('error: --width and --height must be integers (px)');
+      }
+      viewportStrs.push(`${opts.width}x${opts.height}`);
+      // A raw phone-sized window is NOT a phone: touch-gated mobile UI still
+      // renders its desktop variant. Say so once, on the path where the caller
+      // was clearly after a phone.
+      if (parseInt(String(opts.width), 10) <= 500) {
+        console.error(muted('Tip: --device mobile emulates a real handset (touch events, mobile user-agent, DPR) — a raw viewport only resizes the window.'));
+      }
+    }
     const customViewports: Viewport[] = [
       ...deviceNames.map(resolveDevice),
       ...viewportStrs.map(parseViewportString),
@@ -395,18 +424,14 @@ export const pageScreenshotCommand = new Command('screenshot')
       camera = await uploadCameraFeed(projectGuid, opts.camera);
     }
 
-    if (opts.action !== undefined && opts.eval !== undefined) {
-      throw new Error('Pass either --action or --eval (its alias), not both');
-    }
-    const actionJs: string | undefined = opts.action ?? opts.eval;
-
     // The pre-capture script the server runs after the post-load delay: the
     // --wait-for gate first (so the shot waits for the state, deterministically),
-    // then the caller's --action. Both are the same in-page primitive, so they
+    // then the caller's --action (with any alias-flag scripts folded in by
+    // actionScript above). All the same in-page primitive, so they
     // compose into one script rather than needing a second server round-trip.
     const preCapture = [
       opts.waitFor ? buildWaitForGate(opts.waitFor, waitForTimeoutMs) : '',
-      actionJs ?? '',
+      actionScript,
     ].filter(Boolean).join('\n');
 
     const body = {
@@ -554,9 +579,9 @@ export const pageScreenshotCommand = new Command('screenshot')
     }
   }));
 
-// Register the JS-intent guesses as hidden decoys (value-taking, so they swallow
-// the script) — the action turns any of them into the "--action" redirect above.
-for (const f of ACTION_DECOY_FLAGS) pageScreenshotCommand.addOption(new Option(`${f} <value>`).hideHelp());
+// Register the JS-intent guesses as hidden aliases for --action (value-taking,
+// so they capture the script) — the action folds them into the pre-capture body.
+for (const f of ACTION_ALIAS_FLAGS) pageScreenshotCommand.addOption(new Option(`${f} <js>`, 'Alias for --action').hideHelp());
 
 // `screenshot` captures the page AFTER load + settle (+ optional --wait-for gate
 // and --action). There is no scroll-to-a-position lever (agents reach for

--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -1,6 +1,6 @@
-import { Command } from 'commander';
-import { readFileSync, existsSync, statSync } from 'fs';
-import { dirname, extname, relative, resolve } from 'path';
+import { Command, Option } from 'commander';
+import { readFileSync, existsSync, statSync, mkdirSync, writeFileSync } from 'fs';
+import { dirname, extname, relative, resolve, sep } from 'path';
 import { post } from '../api.js';
 import { resolveProjectContext, getConfigPath, getProjectRoot, shouldIgnore } from '../config.js';
 import { SCRATCH_IGNORE } from '../setup.js';
@@ -190,19 +190,23 @@ sandboxCommand
   // an interpreter token, or a --file extension - see resolveLanguage().
   .option('--language <language>', 'Language: js, py, or bash (required unless pinned by an interpreter token or --file extension)')
   .option('--file <path>', 'Read the code body from a file instead of the inline <code> arg; --language is inferred from the extension when not given')
+  // `--code "<code>"` is the natural first guess for passing inline code (the
+  // positional arg is the canonical spelling). Accept it as a working alias
+  // rather than bouncing the guess into an unknown-option --help detour.
+  .addOption(new Option('--code <code>', 'Alias for the positional inline <code> arg').hideHelp())
   .option('--timeout <seconds>', 'Execution timeout in seconds', '30')
   .option(
     '--input <path>',
     'Narrow to specific project files instead of auto-mirroring the whole tree (repeatable). Use this only for >1 GB projects or when you want surgical control.',
     (v: string, prev?: string[]) => [...(prev ?? []), v],
   )
-  // Commander maps a `--no-` prefixed flag to the un-prefixed camelCase name
-  // (`opts.syncOutput`); the explicit `[]` default stops commander's negated-
-  // boolean convention from defaulting it to `true`. Collected as an array so
-  // the flag is repeatable.
+  // Named "discard", not "no-sync": in Gipity vocabulary "sync" means the
+  // local<->cloud file sync, so a no-sync spelling reads as "give me the file
+  // locally, just don't sync it" - which is the tmp/ scratch path below, not
+  // this flag. Collected as an array so the flag is repeatable.
   .option(
-    '--no-sync-output <glob>',
-    'Do not persist run outputs matching this glob back to the project (repeatable). For byproducts you want to inspect once but never keep, e.g. --no-sync-output "docs/preview*". Supports *, **, and dir/ prefixes.',
+    '--discard-output <glob>',
+    'Discard run outputs matching this glob entirely - not saved, not returned (repeatable). To LOOK at an output without keeping it, write it under tmp/ instead: scratch outputs land on local disk only and never enter the project. Supports *, **, and dir/ prefixes.',
     (v: string, prev: string[]) => [...prev, v],
     [] as string[],
   )
@@ -211,6 +215,11 @@ sandboxCommand
 By default the whole project is auto-mirrored into /work/ (up to 1 GB) -
 so your code can reference project files by their relative path, and any
 file you write lands back in the project. No manual copy needed.
+
+Exception: tmp/ is scratch. An output written under tmp/ comes back to
+your local tmp/ for inspection but is never saved to the project - use it
+for previews and other look-once artifacts (no cleanup needed). To drop
+an output entirely, --discard-output <glob>.
 
 Use --input only for projects over the auto-mirror cap, or when you want
 to restrict what the sandbox sees.
@@ -227,6 +236,11 @@ Examples:
   # Python reading a project CSV (auto-mirror)
   $ gipity sandbox run --language python \\
       "import pandas as pd; print(pd.read_csv('data/sales.csv').describe())"
+
+  # Preview a generated PDF without saving the preview: write it to tmp/
+  $ gipity sandbox run bash \\
+      "pdftoppm -png -r 90 docs/report.pdf tmp/preview"
+  # -> tmp/preview-1.png lands on local disk only; Read it, done.
 
   # Run a script file directly (language inferred from .py)
   $ gipity sandbox run --file build_report.py
@@ -261,6 +275,14 @@ GCC/Rust).
     let inlineCode: string | undefined;
     let filePath: string | undefined = opts.file;
     let langFromInterp: string | undefined;
+    // --code alias: fold it into the positional slot before the shape checks.
+    if (opts.code !== undefined) {
+      if (args.length) {
+        console.error(clrError('Pass the code once: either positionally or via --code, not both'));
+        process.exit(1);
+      }
+      args = [opts.code];
+    }
     if (args.length >= 2 && INTERPRETERS[args[0].toLowerCase()] !== undefined) {
       langFromInterp = INTERPRETERS[args[0].toLowerCase()];
       const rest = args.slice(1).join(' ');
@@ -300,11 +322,11 @@ GCC/Rust).
     // missing language costs nothing but the message.
     const language = resolveLanguage({ langFromInterp, langOpt: opts.language, filePath, inlineCode });
 
-    // Validate --no-sync-output globs while we're still pre-network: an empty
+    // Validate --discard-output globs while we're still pre-network: an empty
     // pattern (e.g. a quoting mishap) would silently match nothing server-side.
-    const noSyncOutput: string[] = opts.syncOutput ?? [];
-    if (noSyncOutput.some((g) => !g.trim())) {
-      console.error(clrError('--no-sync-output requires a non-empty glob (e.g. --no-sync-output "docs/preview*")'));
+    const discardOutput: string[] = opts.discardOutput ?? [];
+    if (discardOutput.some((g) => !g.trim())) {
+      console.error(clrError('--discard-output requires a non-empty glob (e.g. --discard-output "*.ppm")'));
       process.exit(1);
     }
 
@@ -351,6 +373,7 @@ GCC/Rust).
         stderrTruncated?: boolean;
         outputFiles?: string[];
         skippedOutputFiles?: string[];
+        scratchFiles?: { path: string; contentBase64: string }[];
         mirroredCount?: number;
         autoMirrorSkipped?: { reason: string; totalBytes: number };
         mirrorWarnings?: string[];
@@ -366,8 +389,9 @@ GCC/Rust).
       cwd,
       // The filter must run SERVER-side (in the output extractor): skipping
       // only in the CLI would still write the files into project storage and
-      // make every later sync propose deleting them.
-      noSyncOutput: noSyncOutput.length ? noSyncOutput : undefined,
+      // make every later sync propose deleting them. (`noSyncOutput` is the
+      // wire name for --discard-output.)
+      noSyncOutput: discardOutput.length ? discardOutput : undefined,
     });
     const res = opts.json
       ? await doRun()
@@ -383,8 +407,26 @@ GCC/Rust).
       await sync({ interactive: false, progress: opts.json ? undefined : createProgressReporter() });
     }
 
+    // Scratch outputs (tmp/ and friends) never enter the project: the server
+    // returns their bytes inline instead of persisting them, and we land them
+    // here. The scratch namespace is ignored by sync in both directions, so
+    // the file exists on local disk only - inspect it, no cleanup required.
+    const scratchWritten: string[] = [];
+    if (res.data.scratchFiles?.length) {
+      const base = resolve(getProjectRoot() ?? process.cwd());
+      for (const f of res.data.scratchFiles) {
+        const rel = f.path.replace(/\\/g, '/');
+        const abs = resolve(base, rel);
+        if (abs !== base && !abs.startsWith(base + sep)) continue; // traversal guard
+        mkdirSync(dirname(abs), { recursive: true });
+        writeFileSync(abs, Buffer.from(f.contentBase64, 'base64'));
+        scratchWritten.push(rel);
+      }
+    }
+
     if (opts.json) {
-      console.log(JSON.stringify({ ...res.data, filesSynced: pulledLocal }));
+      const { scratchFiles: _omit, ...rest } = res.data;
+      console.log(JSON.stringify({ ...rest, scratchFiles: scratchWritten, filesSynced: pulledLocal }));
     } else {
       if (res.data.autoMirrorSkipped) {
         console.error(dim(`Note: ${res.data.autoMirrorSkipped.reason}`));
@@ -416,8 +458,12 @@ GCC/Rust).
           if (pulledLocal) console.log(dim("Not pulled locally - run 'gipity sync' to fetch them."));
         }
       }
+      if (scratchWritten.length > 0) {
+        console.log('\nScratch outputs (local only - never synced or deployed):');
+        for (const f of scratchWritten) console.log(`${f}`);
+      }
       if (res.data.skippedOutputFiles && res.data.skippedOutputFiles.length > 0) {
-        console.log(dim('\nNot persisted (--no-sync-output):'));
+        console.log(dim('\nDiscarded (--discard-output):'));
         for (const f of res.data.skippedOutputFiles) console.log(dim(`${f}`));
       }
       if (res.data.exitCode !== 0) {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -6,6 +6,7 @@ import { homedir, tmpdir } from 'os';
 import { existsSync, mkdirSync, writeFileSync, readFileSync, mkdtempSync, rmSync, cpSync, readdirSync } from 'fs';
 import { resolveCommand, spawnSyncCommand } from './platform.js';
 import { SKILLS_CONTENT, BUILD_VS_NON_BUILD_RULE, DEFINITION_OF_DONE } from './knowledge.js';
+import { DEFAULT_API_BASE, resolveApiBase } from './config.js';
 
 export { SKILLS_CONTENT };
 
@@ -587,9 +588,25 @@ export const GIPITY_BLOCK_END = '<!-- END GIPITY INTEGRATION -->';
  *  them into a generated doc is the wrong layer. The CLI surfaces them where the
  *  agent actually looks: `gipity deploy` prints the live URL, `gipity status` and
  *  `gipity project info` show the URL + GUID. That keeps them authoritative and
- *  avoids stale values frozen into a file. */
-function renderManagedBlock(): string {
-  const body = [SKILLS_CONTENT, BUILD_VS_NON_BUILD_RULE, DEFINITION_OF_DONE].join('\n\n');
+ *  avoids stale values frozen into a file.
+ *
+ *  The one environment value that DOES live here is the API base. The baked
+ *  knowledge text names `https://a.gipity.ai` as the app-services endpoint;
+ *  when this session runs against a different platform instance (GIPITY_API_BASE
+ *  / --api-base, e.g. a local dev server), the project only exists there - an
+ *  agent that copies the public host into app code gets 404s it can't explain.
+ *  So the block is rendered against the resolved base, with a note naming the
+ *  instance. The block is fully regenerated each session, so it tracks the
+ *  environment rather than going stale. */
+function renderManagedBlock(apiBase: string): string {
+  let body = [SKILLS_CONTENT, BUILD_VS_NON_BUILD_RULE, DEFINITION_OF_DONE].join('\n\n');
+  const base = apiBase.replace(/\/+$/, '');
+  if (base !== DEFAULT_API_BASE) {
+    body = body.replaceAll(DEFAULT_API_BASE, base);
+    const note = `> **Platform instance:** this project runs against the Gipity platform at \`${base}\`, not the public \`${DEFAULT_API_BASE}\`. The project and its data exist only on that instance; every API/service URL in this document already points there - never substitute \`a.gipity.ai\`.`;
+    const headingEnd = body.indexOf('\n');
+    body = body.slice(0, headingEnd + 1) + '\n' + note + '\n' + body.slice(headingEnd + 1);
+  }
   return `${GIPITY_BLOCK_BEGIN}\n${body}\n${GIPITY_BLOCK_END}`;
 }
 
@@ -610,8 +627,8 @@ function renderManagedBlock(): string {
  *
  * Exported for unit testing.
  */
-export function applySkillsBlock(existing: string | null): string {
-  const block = renderManagedBlock();
+export function applySkillsBlock(existing: string | null, apiBase: string = DEFAULT_API_BASE): string {
+  const block = renderManagedBlock(apiBase);
   if (existing === null) return block + '\n';
 
   let next: string;
@@ -639,7 +656,7 @@ function writeSkillsFile(relPath: string, wrap?: (block: string) => string): voi
   const path = resolve(process.cwd(), relPath);
   mkdirSync(dirname(path), { recursive: true });
   const existing = existsSync(path) ? readFileSync(path, 'utf-8') : null;
-  const baseNext = applySkillsBlock(existing);
+  const baseNext = applySkillsBlock(existing, resolveApiBase());
   // Frontmatter wrap only applies on first write (no existing content).
   // Re-runs preserve user content outside the managed block, including
   // any frontmatter they may have added themselves.


### PR DESCRIPTION
Two breadth-first rounds over five apps (sandbox CSV, auth recipe box, uploads
vault, i18n welcome, approval desk), Opus builder / Fable analyst+fixer. Stopped
by hand after round 2 per operator request; every fix below was gate-checked and
most were live-proven against the run's dev server before this landing.

Round-2 scores (round-1 baseline →): 02: 8→9 f1 · 05: 5→8 f3 · 06: 9→6* f3 ·
13: 8→8 f4 · 21: 8→9 f1  (*06 regressed on a latent serve-URL bug the sweep
itself exposed, then fixed — see below.)

Highlights:
- file-serve URLs minted against the public prod host instead of the instance's
  own base (buildServeUrl → PUBLIC_API_BASE): uploaded files' URLs never loaded
  on any non-prod instance. Live-proven with a full presigned upload + byte
  readback.
- fresh browser profile per page-tool run: localStorage from one verification no
  longer leaks into the next (live-proven before/after).
- scaffolded artifacts (config comments, gipity.yaml examples) now derive from
  the instance API base instead of asserting a.gipity.ai — the source of a
  13-turn agent spiral on non-prod instances.
- `gipity add` responses carry a read-before-write note at the moment of use
  (a knowledge-doc line alone had already failed to prevent the tax — #190).
- test-run progress streams per-file instead of buffering to the end; callAs
  unknown-user errors name the available fixtures; /api/token validation names
  the missing field; test sandbox cold-start friction documented for follow-up.
- cli test hermeticity: suites no longer read ambient GIPITY_DIR /
  GIPITY_API_BASE (the landing gate was red on an unmodified tree without this).

Closes #365
Closes #366
Closes #367
Closes #369
Closes #370
Closes #372
Closes #373

Repos: platform, cli, registry

Opened by `gw`. Gate: passed.

Closes #145