### PR TITLE
feat: Skill-doc discovery tax: skill read is all-or-nothing and add reports bare filenames, costing ~15 turns of doc-mining before every build

### DIFF
--- a/GIPITY-SKILLS.md
+++ b/GIPITY-SKILLS.md
@@ -29,7 +29,7 @@ All code execution happens on Gipity's hosted platform.
 | `gipity records [query\|schema]` | Query and manage Records API tables |
 | `gipity domain [list\|add\|remove]` | Manage custom domains |
 | `gipity credits` | Check balance and usage |
-| `gipity skill [list\|search\|install]` | Manage agent skills |
+| `gipity skill [list\|read]` | Task docs. `read <name>...` takes several docs at once; `--toc`, `--section <slug>`, `--grep <term>` read one part instead of piping through `head` |
 | `gipity chat [list\|rename\|archive\|delete]` | Manage chats (or `gipity chat "<msg>"` to send) |
 | `gipity gmail [send\|reply\|search\|read]` | Send/read via the user's own Gmail |
 | `gipity rbac [list\|grant\|revoke]` | Manage RBAC policies |

--- a/src/__tests__/cli-cmd-add.test.ts
+++ b/src/__tests__/cli-cmd-add.test.ts
@@ -33,6 +33,27 @@ test('gipity add web-simple posts and prints files', async () => {
   assert.doesNotMatch(r.stdout, /undefined/);
 });
 
+test('gipity add scaffolds compactly and points at the files that carry the conventions', async () => {
+  mock.reset();
+  const files = [
+    'README.md', 'docs/README.md', 'gipity.yaml', 'src/css/gipity-theme.css', 'src/css/styles.css',
+    'src/index.html', 'src/js/config.js', 'src/js/main.js', 'src/js/settings.js',
+  ];
+  mock.on('POST /projects/p_TestProj/add', { body: { data: {
+    kind: 'template', files, title: 'my-app', type: 'web-fullstack',
+  } } });
+  mock.on('GET /projects/p_TestProj/files/tree', { body: { data: [] } });
+  const r = await fresh(['add', 'web-fullstack']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /Start here.*README\.md.*gipity\.yaml.*src\/index\.html/);
+  // Every path still reported, but packed - not one line each, and the kit
+  // catalog no longer spends a line per kit.
+  const lines = r.stdout.split('\n').filter(Boolean);
+  assert.ok(lines.length < 12, `install report too long:\n${r.stdout}`);
+  for (const f of files) assert.ok(r.stdout.includes(f), `missing ${f}`);
+  assert.match(r.stdout, /realtime/);  // kits still discoverable
+});
+
 test('gipity add realtime installs a kit', async () => {
   mock.reset();
   mock.on('POST /projects/p_TestProj/add', { body: { data: {

--- a/src/__tests__/cli-cmd-skill.test.ts
+++ b/src/__tests__/cli-cmd-skill.test.ts
@@ -45,6 +45,92 @@ test('gipity skill read <name> prints content', async () => {
   assert.match(r.stdout, /gipity deploy dev/);
 });
 
+// A doc with real structure, reused by the outline/targeted-read tests.
+const DOC = [
+  '# App Database', '', 'Intro line.', '',
+  '## Queries', '', 'Use `gipity db query`.', '',
+  '```bash', '# not a heading - inside a fence', 'echo hi', '```', '',
+  '## Limits', '', '500 rows / 128 KB per query.', '',
+  '### Per statement', '', '50,000 chars.', '',
+  '## Migrations', '', 'Each file runs once.',
+].join('\n');
+
+function mockDoc(content: string) {
+  mock.reset();
+  mock.on('GET /skills', { body: { data: [
+    { guid: 'sk_TestSkl01', name: 'app-database', description: 'Query the DB', scope: 'platform' },
+    { guid: 'sk_TestSkl02', name: 'app-auth', description: 'Sign users in', scope: 'platform' },
+  ] } });
+  mock.on('GET /skills/sk_TestSkl01', { body: { data: {
+    guid: 'sk_TestSkl01', name: 'app-database', description: 'Query the DB', scope: 'platform', content,
+  } } });
+  mock.on('GET /skills/sk_TestSkl02', { body: { data: {
+    guid: 'sk_TestSkl02', name: 'app-auth', description: 'Sign users in', scope: 'platform',
+    content: '# App Auth\n\n## Sign in\n\nCall Gipity.login().',
+  } } });
+}
+
+test('gipity skill read prints a length + section map above the doc', async () => {
+  mockDoc(DOC);
+  const r = await fresh(['skill', 'read', 'app-database']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /app-database.*24 lines/);
+  // Section slugs come from the H2s, not the lone H1 and not the fenced `#` line.
+  assert.match(r.stdout, /queries, limits, migrations/);
+  assert.doesNotMatch(r.stdout, /not-a-heading/);
+  assert.match(r.stdout, /Each file runs once\./);
+});
+
+test('gipity skill read --toc prints the outline only', async () => {
+  mockDoc(DOC);
+  const r = await fresh(['skill', 'read', 'app-database', '--toc']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /per-statement/);
+  assert.doesNotMatch(r.stdout, /Each file runs once\./);
+});
+
+test('gipity skill read --section prints one section with its subsections', async () => {
+  mockDoc(DOC);
+  const r = await fresh(['skill', 'read', 'app-database', '--section', 'limits']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /500 rows \/ 128 KB per query/);
+  assert.match(r.stdout, /50,000 chars/);          // subsection rides along
+  assert.doesNotMatch(r.stdout, /Each file runs once\./);
+});
+
+test('gipity skill read --grep prints the matching section, not a bare line', async () => {
+  mockDoc(DOC);
+  const r = await fresh(['skill', 'read', 'app-database', '--grep', '128 KB']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /## Limits/);
+  assert.doesNotMatch(r.stdout, /Use `gipity db query`/);
+});
+
+test('gipity skill read --section with no match lists the available sections', async () => {
+  mockDoc(DOC);
+  const r = await fresh(['skill', 'read', 'app-database', '--section', 'nope']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /Sections: app-database, queries, limits/);
+});
+
+test('gipity skill read takes several names in one call', async () => {
+  mockDoc(DOC);
+  const r = await fresh(['skill', 'read', 'app-database', 'app-auth']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /Each file runs once\./);
+  assert.match(r.stdout, /Call Gipity\.login\(\)/);
+});
+
+test('gipity skill read --json carries the outline alongside the content', async () => {
+  mockDoc(DOC);
+  const r = await fresh(['skill', 'read', 'app-database', '--json']);
+  assert.equal(r.status, 0, r.stderr);
+  const doc = JSON.parse(r.stdout);
+  assert.equal(doc.lines, 24);
+  assert.ok(doc.sections.some((s: { slug: string }) => s.slug === 'limits'));
+  assert.match(doc.content, /Each file runs once\./);
+});
+
 test('gipity skill read <kit> falls back to an installed kit README when no skill doc exists', async () => {
   mock.reset();
   // Catalog has no "chatbot" skill.

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -37,6 +37,34 @@ function catalogText(): string {
   ].join('\n\n');
 }
 
+/** Pack names onto as few lines as possible. A scaffold prints 16-40 paths;
+ *  one per line pushed the success line and the notes past the ~30 lines an
+ *  agent keeps when it defensively pipes the install through `tail`. */
+function packNames(names: string[], width = 96): string[] {
+  const lines: string[] = [];
+  let cur = '';
+  for (const n of names) {
+    if (cur && cur.length + 1 + n.length > width) { lines.push(cur); cur = ''; }
+    cur = cur ? `${cur} ${n}` : n;
+  }
+  if (cur) lines.push(cur);
+  return lines;
+}
+
+// The files a freshly scaffolded app is meant to be read in order of, most
+// orienting first. Every template file carries header comments describing the
+// contract it establishes (the injected SDK, apiBase stamping, theme tokens,
+// the permissions block), but nothing said WHICH files those are - so agents
+// re-opened the whole scaffold to find out. Only paths the install actually
+// wrote are printed, so this never points at a file that isn't there.
+const ORIENTATION_FILES = [
+  'README.md',
+  'gipity.yaml',
+  'src/index.html',
+  'src/js/main.js',
+  'src/css/styles.css',
+];
+
 interface AddResponse {
   kind: 'template' | 'kit';
   files: string[];
@@ -222,8 +250,8 @@ export const addCommand = new Command('add')
     if (!opts.json && !process.stdout.isTTY) {
       const isKit = KITS.some(k => k.key === name);
       console.error(muted(isKit
-        ? 'Installing kit (server-side install pipeline)...'
-        : 'Installing (server writes files + generates favicons; first add for a title can take ~10s)...'));
+        ? 'Installing kit (server-side install pipeline, ~1-2s)...'
+        : 'Installing (server writes files + generates favicons, ~5-10s)...'));
     }
     const doAdd = () => post<{ data: AddResponse }>(`/projects/${config.projectGuid}/add`, body);
     const res = opts.json
@@ -244,7 +272,16 @@ export const addCommand = new Command('add')
     } else {
       console.log(success(`Scaffolded "${data.title}" (${data.type}) - ${data.files.length} files:`));
     }
-    for (const f of data.files) console.log(`${f}`);
+    for (const line of packNames(data.files)) console.log(line);
+    // Point at the files that teach this app's conventions, so the next step is
+    // one targeted read instead of re-opening the whole scaffold to find them.
+    const startHere = data.kind === 'kit'
+      ? data.files.filter(f => /(^|\/)README\.md$/.test(f))
+      : ORIENTATION_FILES.filter(f => data.files.includes(f));
+    if (startHere.length) {
+      console.log('');
+      console.log(muted(`Start here - their header comments carry the conventions you build inside: ${startHere.join('  ')}`));
+    }
     if (data.notes?.length) {
       console.log('');
       for (const n of data.notes) console.log(n);
@@ -258,11 +295,13 @@ export const addCommand = new Command('add')
       console.warn(warning(`Re-run \`gipity add ${data.kit ?? name}${opts.force ? ' --force' : ''}\` to retry the dropped files.`));
     }
     // After scaffolding an app, point at kits as the next step - they add
-    // features (multiplayer, etc.) into the app you just created.
+    // features (multiplayer, etc.) into the app you just created. Keys only:
+    // one wrapped line keeps the whole install report short enough to read
+    // without truncating, and `gipity add --list` has the per-kit blurbs.
     if (data.kind !== 'kit' && KITS.length > 0) {
       console.log('');
-      console.log(muted('Add features with kits (gipity add <kit>):'));
-      for (const k of KITS) console.log(muted(`  ${k.key}  - ${k.hint}`));
+      console.log(muted('Add features with kits (gipity add <kit>, gipity add --list for what each does):'));
+      for (const line of packNames(KITS.map(k => k.key))) console.log(muted(`  ${line}`));
     }
     if (syncResult.applied > 0) {
       console.log(`\nPulled ${syncResult.applied} files to local.`);

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -28,6 +28,118 @@ interface SkillDetail extends SkillSummary {
   content: string;
 }
 
+// ─── Doc structure ──────────────────────────────────────────────────────────
+//
+// `skill read` used to be all-or-nothing: the whole doc or nothing. Agents
+// budgeting context piped every read through a guessed `head -N` (and grepped
+// the output when they wanted one fact), so guidance past the cut was silently
+// dropped and nothing told them the doc was longer than what they read. The
+// outline below powers three fixes: a one-line map above every read (survives
+// `head -N`, so a truncated read is visibly truncated), `--toc`, and targeted
+// `--section` / `--grep` reads.
+
+interface Section {
+  level: number;
+  title: string;
+  slug: string;
+  /** 1-based first/last line of the section, subsections included. */
+  start: number;
+  end: number;
+}
+
+function slugify(title: string): string {
+  return title.toLowerCase().replace(/[`*_]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+/** Markdown headings, skipping anything inside a fenced code block (shell
+ *  comments in examples start with `#` too). A section runs until the next
+ *  heading at the same or a shallower level, so it carries its subsections. */
+function parseSections(lines: string[]): Section[] {
+  const out: Section[] = [];
+  let fenced = false;
+  lines.forEach((line, i) => {
+    if (/^\s*(```|~~~)/.test(line)) { fenced = !fenced; return; }
+    if (fenced) return;
+    const m = /^(#{1,6})\s+(.*\S)\s*$/.exec(line);
+    if (!m) return;
+    out.push({ level: m[1].length, title: m[2], slug: slugify(m[2]), start: i + 1, end: lines.length });
+  });
+  out.forEach((s, i) => {
+    const next = out.find((o, j) => j > i && o.level <= s.level);
+    if (next) s.end = next.start - 1;
+  });
+  return out;
+}
+
+/** The heading level worth listing in the one-line map: the shallowest level
+ *  with more than one heading (docs open with a single `# Title`, so that lone
+ *  H1 is never the useful outline), else the shallowest level present. */
+function outlineLevel(sections: Section[]): number {
+  const levels = [...new Set(sections.map(s => s.level))].sort((a, b) => a - b);
+  return levels.find(l => sections.filter(s => s.level === l).length > 1) ?? levels[0];
+}
+
+function sectionText(lines: string[], s: Section): string {
+  return lines.slice(s.start - 1, s.end).join('\n').replace(/\s+$/, '');
+}
+
+const MAX_MAPPED_SECTIONS = 12;
+
+/** One line above every read: how long the doc is and what is in it, with the
+ *  flag for pulling one part inline. Printed to stdout so it survives an
+ *  agent's `| head -N`. */
+function mapLine(name: string, lines: string[], sections: Section[]): string {
+  const head = `${bold(name)} ${muted(`· ${lines.length} lines`)}`;
+  if (sections.length === 0) return head;
+  const shown = sections.filter(s => s.level === outlineLevel(sections));
+  const names = shown.slice(0, MAX_MAPPED_SECTIONS).map(s => s.slug).join(', ');
+  const more = shown.length > MAX_MAPPED_SECTIONS ? `, +${shown.length - MAX_MAPPED_SECTIONS} more (--toc)` : '';
+  return `${head} ${muted(`· sections (--section <slug>): ${names}${more}`)}`;
+}
+
+function tocText(sections: Section[]): string {
+  return sections
+    .map(s => `${String(s.start).padStart(5)}  ${'  '.repeat(s.level - 1)}${s.slug}${muted(` - ${s.title}`)}`)
+    .join('\n');
+}
+
+interface ReadOpts { json?: boolean; toc?: boolean; section?: string; grep?: string; }
+
+/** Apply --toc / --section / --grep to a doc. Returns the text to print, or
+ *  null when the filter matched nothing (caller reports it and exits 1). */
+function filterContent(content: string, sections: Section[], opts: ReadOpts): string | null {
+  const lines = content.split('\n');
+  if (opts.toc) return tocText(sections);
+
+  let hits: Section[] = [];
+  if (opts.section) {
+    const want = slugify(opts.section);
+    hits = sections.filter(s => s.slug === want);
+    if (hits.length === 0) hits = sections.filter(s => s.slug.includes(want));
+  } else if (opts.grep) {
+    let re: RegExp;
+    try { re = new RegExp(opts.grep, 'i'); }
+    catch { throw new Error(`--grep "${opts.grep}" is not a valid regex.`); }
+    // Deepest matching section per hit: the smallest chunk that still answers
+    // the question, rather than the whole chapter it sits in.
+    const matched = new Set<Section>();
+    lines.forEach((line, i) => {
+      if (!re.test(line)) return;
+      const owning = sections.filter(s => s.start <= i + 1 && i + 1 <= s.end);
+      const deepest = owning[owning.length - 1];
+      if (deepest) matched.add(deepest);
+    });
+    hits = sections.filter(s => matched.has(s));
+  } else {
+    return content;
+  }
+
+  if (hits.length === 0) return null;
+  // Drop sections already contained in an outer hit so nothing prints twice.
+  const outer = hits.filter(s => !hits.some(o => o !== s && o.start <= s.start && s.end <= o.end));
+  return outer.map(s => sectionText(lines, s)).join('\n\n');
+}
+
 export const skillCommand = new Command('skill')
   .description('Task docs - read the matching skill before building');
 
@@ -46,44 +158,81 @@ skillCommand
     const width = res.data.reduce((m, s) => Math.max(m, s.name.length), 0);
     printList(res.data, opts, 'No skills available.', s =>
       `  ${bold(s.name.padEnd(width))}  ${muted(s.description)}`,
-      'Read one with `gipity skill read <name>`:'
+      'Read with `gipity skill read <name> [<name>...]` (one turn, many docs; `--toc`, `--section <slug>` or `--grep <term>` for one part):'
     );
   }));
 
 skillCommand
-  .command('read <name>')
-  .description('Read a skill')
+  .command('read <names...>')
+  .description('Read one or more skills (whole doc, or one part with --toc/--section/--grep)')
+  .option('--toc', 'Print the doc outline (section slugs + line numbers) instead of the content')
+  .option('--section <slug>', 'Print only this section (slug or heading text; subsections included)')
+  .option('--grep <term>', 'Print only the sections matching this term (case-insensitive regex)')
   .option('--json', 'Output as JSON')
-  .action((name: string, opts) => run('Read', async () => {
+  .action((names: string[], opts: ReadOpts) => run('Read', async () => {
     const { config } = await resolveProjectContext();
     if (!config.agentGuid) {
       console.error(clrError('No agent configured for this project. Run `gipity init` to refresh.'));
       process.exit(1);
     }
     const listRes = await get<{ data: SkillSummary[] }>(`/skills?agent=${config.agentGuid}`);
-    const match = listRes.data.find(s => s.name.toLowerCase() === name.toLowerCase());
-    if (!match) {
-      // No catalog skill — but if a kit by this name is installed, its README is
-      // the guidance the agent is after. Surface it instead of dead-ending.
-      const readme = readInstalledKitReadme(name);
-      if (readme) {
-        if (opts.json) {
-          console.log(JSON.stringify({ name, source: 'kit-readme', content: readme }, null, 2));
-        } else {
-          console.log(muted(`No skill doc for "${name}"; showing the installed kit's README (src/packages/${name}/README.md):\n`));
-          console.log(readme);
-        }
-        return;
-      }
-      console.error(clrError(`Skill "${name}" not found. Run: gipity skill list`));
-      process.exit(1);
-    }
 
-    const res = await get<{ data: SkillDetail }>(`/skills/${match.guid}?agent=${config.agentGuid}`);
+    const jsonDocs: unknown[] = [];
+    let failed = false;
+    let printed = 0;
+
+    for (const name of names) {
+      const match = listRes.data.find(s => s.name.toLowerCase() === name.toLowerCase());
+      let content: string;
+      let detail: Record<string, unknown>;
+      let note: string | null = null;
+
+      if (match) {
+        const res = await get<{ data: SkillDetail }>(`/skills/${match.guid}?agent=${config.agentGuid}`);
+        content = res.data.content;
+        detail = { ...res.data };
+      } else {
+        // No catalog skill — but if a kit by this name is installed, its README is
+        // the guidance the agent is after. Surface it instead of dead-ending.
+        const readme = readInstalledKitReadme(name);
+        if (!readme) {
+          console.error(clrError(`Skill "${name}" not found. Run: gipity skill list`));
+          failed = true;
+          continue;
+        }
+        content = readme;
+        detail = { name, source: 'kit-readme' };
+        note = muted(`No skill doc for "${name}"; showing the installed kit's README (src/packages/${name}/README.md):`);
+      }
+
+      const lines = content.split('\n');
+      const sections = parseSections(lines);
+      const filtered = filterContent(content, sections, opts);
+      if (filtered === null) {
+        const what = opts.section ? `section "${opts.section}"` : `match for "${opts.grep}"`;
+        console.error(clrError(`No ${what} in "${name}". Sections: ${sections.map(s => s.slug).join(', ') || '(none)'}`));
+        failed = true;
+        continue;
+      }
+
+      if (opts.json) {
+        jsonDocs.push({
+          ...detail,
+          content: filtered,
+          lines: lines.length,
+          sections: sections.map(s => ({ slug: s.slug, title: s.title, level: s.level, line: s.start })),
+        });
+        continue;
+      }
+      if (printed > 0) console.log('');  // blank line between docs in a multi-name read
+      if (note) console.log(note);
+      console.log(mapLine(name, lines, sections));
+      console.log(filtered);
+      printed++;
+    }
 
     if (opts.json) {
-      console.log(JSON.stringify(res.data, null, 2));
-    } else {
-      console.log(res.data.content);
+      console.log(JSON.stringify(names.length === 1 ? jsonDocs[0] ?? null : jsonDocs, null, 2));
     }
+    if (failed) process.exit(1);
   }));


### PR DESCRIPTION
## Problem

Consolidated from cli#182, cli#186 and EasyClaw#437: every build paid a discovery tax before a line of code got written.

1. **`gipity skill read` was all-or-nothing.** Agents budgeted context by piping every read through a guessed `head -N` (observed N: 120..400, 6-11 docs per build), so guidance past the cut was silently dropped and nothing told the agent the doc was longer than what it read. Targeted lookups were improvised as `grep -n -A 30` / `sed -n '120,260p'` over CLI output.
2. **`gipity add` reported a bare filename list**, one path per line plus a per-kit catalog dump (~30 lines for a `web-fullstack` scaffold). Agents then spent ~5 Read turns re-opening `gipity.yaml`, `index.html`, `main.js`, `config.js`, `styles.css` to find the conventions, because nothing said which files carried them.
3. **Install-time opacity.** The `add` wait printed an open-ended "first add for a title can take ~10s", and the long unbounded report pushed agents to wrap installs in `timeout: 180000` and `| tail -30` (which truncates the success line and notes, exactly the wrong end).

## Root-cause fix (CLI, `src/commands/`)

**`skill.ts`** now parses the doc's markdown outline (fenced code blocks excluded, so a `# comment` line in a shell example is not mistaken for a heading) and uses it three ways:

- Every read prints one map line first: `app-database · 312 lines · sections (--section <slug>): overview, queries, limits, ...`. It goes to stdout above the body, so it survives an agent's `| head -N`: a truncated read is now visibly truncated, and the missing part is one flag away. It also teaches the flag in-band at the moment of use, with no always-loaded doc text.
- `--toc` prints the outline only (slug + line number + heading, indented by level).
- `--section <slug>` prints one section including its subsections. `--grep <term>` prints the deepest sections matching a case-insensitive regex, so the answer arrives with its context instead of as a bare grep line. A miss lists the available slugs and exits 1.
- `read <names...>` is variadic, so `gipity skill read app-database app-auth` replaces the `echo "=====AUTH====="` two-doc hack in a single turn.
- `--json` carries `lines` + `sections[]` alongside `content` (object for one name, array for several).

**`add.ts`**: installed paths and kit keys pack onto wrapped lines (a 16-file scaffold report drops from ~31 lines to ~10, small enough that no `tail` guard is warranted); a `Start here` line names the installed files whose header comments carry the conventions (README.md, gipity.yaml, src/index.html, src/js/main.js, src/css/styles.css, filtered to what the install actually wrote, or the kit's own README for a kit); the install wait states a bounded `~5-10s` / `~1-2s` instead of an open-ended warning.

`GIPITY-SKILLS.md`: the command table advertised non-existent `skill search|install` subcommands; corrected to `list|read` with the new flags.

No generated files were touched (no `docs/` source changed, so `src/knowledge.ts` and `src/catalog.ts` are untouched). New tests cover the outline parse, `--toc`, `--section`, `--grep`, the multi-name read, the JSON shape, and the compact install report. `npm run test:smoke` passes (1106 pass); its single failure, `cli-cmd-text.test.js`, is pre-existing and environmental: it reads `platform/packages/shared/src/text-analysis.ts` from a sibling repo that does not exist in this isolated worktree.

**Not fixed here (sibling repos):** EasyClaw#437, and the `registry/` half of cli#186 (design tokens discoverable only by grepping the generated `src/css/gipity-theme.css`), plus the knowledge/skill docs that still describe `skill read` as whole-doc-only. Those need changes in `platform/` and `registry/`, which cannot be made from this worktree.

## Scorecard from the run that motivated this

```
(no scorecard on #189 itself - it was human-filed; the two source issues carry theirs)

cli#182 (c_c3dg5kjj):
success: true (db)  turns: 78  tools: 50 total, 0 failed
tool time: Bash×12 50.1s (max 16.0s), Write×21 14.4s, Edit×7 3.5s, Read×9 1.5s

cli#186 (c_w7g6dkcm):
success: true (db)  turns: 77  tools: 48 total, 0 failed
tool time: Bash×11 43.7s (max 10.6s), Write×24 17.0s, Edit×6 2.5s, Read×6 1.0s
```

Closes #189
🤖 Generated with [Claude Code](https://claude.com/claude-code)
